### PR TITLE
adding --recurse and --only-rb options

### DIFF
--- a/bin/ripper-tags
+++ b/bin/ripper-tags
@@ -26,6 +26,9 @@ end
 if ARGV.delete('--only-rb')
   only_ruby = true
 end
+if ARGV.delete('--ignore-errors')
+  ignore_errors = true
+end
 
 ARGV.each do |file|
   begin
@@ -80,8 +83,10 @@ ARGV.each do |file|
       end
     end
   rescue Exception => e
-    STDERR.puts [e, file].inspect
-    raise e
+    unless ignore_errors
+      STDERR.puts [e, file].inspect
+      raise e
+    end
   end
 end
 


### PR DESCRIPTION
Hey,

FINALLY I found WORKING ctags generator. _THANKS_

Here is my patch which adds two options, so one is able to run recursively and pick up only Ruby sources. Very useful.

If you like it, I can go ahead and modify README as well.
