### PR TITLE
fixing minor issue in the vim formatter

### DIFF
--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -26,11 +26,11 @@ module RipperTags
     end
 
     def display_constant(const)
-      const.gsub('::', '.')
+      const.to_s.gsub('::', '.')
     end
 
     def display_pattern(tag)
-      tag.fetch(:pattern).gsub('\\','\\\\\\\\').gsub('/','\\/')
+      tag.fetch(:pattern).to_s.gsub('\\','\\\\\\\\').gsub('/','\\/')
     end
 
     def display_class(tag)


### PR DESCRIPTION
Addressing:

Generating ctags for eventmachine-0.12.10
ERROR:  While executing gem ... (NoMethodError)
    undefined method `gsub' for :call:Symbol

I've tested master against my huge gem collection and everything is good.
Except UTF8 encoding issues in about 10 files (solved with --force :-)
