### PR TITLE
there was a chomp on 'symbol' at line 152 @ parser.rb, this fixed it for...

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -144,7 +144,7 @@ class Parser < Ripper
           gen
         end
       when "has_many", "has_and_belongs_to_many"
-        a = args[1][0]
+        a = args[1][0].to_s
         kind = name.to_sym
         gen = []
         gen << [:rails_def, kind, a, line]


### PR DESCRIPTION
... me.

```
/Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/parser.rb:152:in `on_method_add_arg': undefined method `chomp' for :call:Symbol (NoMethodError)
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/parser.rb:74:in `on_command'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:113:in `parse'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:113:in `parse_file'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:121:in `tag_extractor'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:93:in `block in each_tag'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:58:in `block in each_file'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block (2 levels) in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block (2 levels) in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block (2 levels) in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:51:in `block in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `each'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `each'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `each'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:48:in `block in find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `each'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:42:in `find_files'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:58:in `each_file'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/data_reader.rb:90:in `each_tag'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:115:in `block in run'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/vim_formatter.rb:17:in `block in with_output'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/default_formatter.rb:20:in `block in with_output'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/default_formatter.rb:19:in `open'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/default_formatter.rb:19:in `with_output'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags/vim_formatter.rb:14:in `with_output'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:114:in `run'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:96:in `call'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:96:in `block in process_args'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:84:in `block in option_parser'
  from /Users/pavel/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/optparse.rb:882:in `initialize'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:29:in `new'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:29:in `option_parser'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/lib/ripper-tags.rb:89:in `process_args'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bundler/gems/ripper-tags-ec0cf75208d8/bin/ripper-tags:10:in `<top (required)>'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bin/ripper-tags:23:in `load'
  from /Users/pavel/.rvm/gems/ruby-1.9.3-p448@valkyrie/bin/ripper-tags:23:in `<main>'
```
