### PR TITLE
Handle ensure and multiple rescue clauses in class definitions

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -255,7 +255,7 @@ end
       end
     end
 
-    def on_module_or_class(kind, name, superclass, body)
+    def on_module_or_class(kind, name, superclass, *body)
       name, line = *name
       @namespace << name
 
@@ -284,12 +284,12 @@ end
       @namespace.pop
     end
 
-    def on_module(name, body = nil)
-      on_module_or_class(:module, name, nil, body)
+    def on_module(name, *body)
+      on_module_or_class(:module, name, nil, *body)
     end
 
-    def on_class(name, superclass, body = nil)
-      on_module_or_class(:class, name, superclass, body)
+    def on_class(name, superclass, *body)
+      on_module_or_class(:class, name, superclass, *body)
     end
 
     def on_private()   @current_access = 'private'   end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -339,4 +339,32 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 1, tags.size
     assert_equal 'Foo', tags[0][:name]
   end
+
+  def test_extract_class_with_ensure
+    tags = extract(<<-EOC)
+      class Foo
+        i = 1
+      ensure
+        i = 2
+      end
+    EOC
+
+    assert_equal 1, tags.size
+    assert_equal 'Foo', tags[0][:name]
+  end
+
+  def test_extract_class_with_mutiple_rescue_clauses
+    tags = extract(<<-EOC)
+      class Foo
+        i = 1
+      rescue ArgumentError
+        i = 2
+      rescue TypeError
+        i = 3
+      end
+    EOC
+
+    assert_equal 1, tags.size
+    assert_equal 'Foo', tags[0][:name]
+  end
 end


### PR DESCRIPTION
This fixes #19.

Note that there is a failing test, but it has something to do with rails associations and was failing prior to this change.
