### PR TITLE
update version to 1.3

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -8,7 +8,7 @@ require 'ripper-tags/vim_formatter'
 require 'ripper-tags/json_formatter'
 
 module RipperTags
-  def self.version() "0.1.2" end
+  def self.version() "0.1.3" end
 
   def self.default_options
     OpenStruct.new \


### PR DESCRIPTION
I noticed that running ripper-tags -v is still showing 1.2, even tho I was using the 1.3 release.
Fixed updating the version to 1.3