### PR TITLE
correctly open file with bom symbol

### DIFF
--- a/lib/ripper-tags/data_reader.rb
+++ b/lib/ripper-tags/data_reader.rb
@@ -71,7 +71,7 @@ module RipperTags
     end
 
     def read_file(filename)
-      str = File.open(filename, 'r:utf-8') {|f| f.read }
+      str = File.open(filename, 'r:bom|utf-8') {|f| f.read }
       normalize_encoding(str)
     end
 


### PR DESCRIPTION
When file contains bom symbol ripper-tags build pattern in tags with bom and vim can't find tag with those patterns.
