### PR TITLE
Clean the tag path if it's not tag-relative

### DIFF
--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -31,7 +31,7 @@ module RipperTags
       if options.tag_relative && !stdout? && path.index('/') != 0
         Pathname.new(path).relative_path_from(tag_file_dir).to_s
       else
-        path
+        Pathname.new(path).cleanpath.to_s
       end
     end
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -40,22 +40,22 @@ class FormattersTest < Test::Unit::TestCase
 
   def test_vim
     vim = formatter_for(:format => 'vim')
-    assert_equal %{C\t./script.rb\t/^class C < D$/;"\tc\tclass:A.B\tinherits:D}, vim.format(build_tag(
+    assert_equal %{C\tscript.rb\t/^class C < D$/;"\tc\tclass:A.B\tinherits:D}, vim.format(build_tag(
       :kind => 'class', :name => 'C',
       :pattern => "class C < D",
       :class => 'A::B', :inherits => 'D'
     ))
-    assert_equal %{M\t./script.rb\t/^module M$/;"\tm\tclass:A.B}, vim.format(build_tag(
+    assert_equal %{M\tscript.rb\t/^module M$/;"\tm\tclass:A.B}, vim.format(build_tag(
       :kind => 'module', :name => 'M',
       :pattern => "module M",
       :class => 'A::B'
     ))
-    assert_equal %{imethod\t./script.rb\t/^  def imethod(*args)$/;"\tf\tclass:A.B}, vim.format(build_tag(
+    assert_equal %{imethod\tscript.rb\t/^  def imethod(*args)$/;"\tf\tclass:A.B}, vim.format(build_tag(
       :kind => 'method', :name => 'imethod',
       :pattern => "  def imethod(*args)",
       :class => 'A::B'
     ))
-    assert_equal %{smethod\t./script.rb\t/^  def self.smethod(*args)$/;"\tF\tclass:A.B}, vim.format(build_tag(
+    assert_equal %{smethod\tscript.rb\t/^  def self.smethod(*args)$/;"\tF\tclass:A.B}, vim.format(build_tag(
       :kind => 'singleton method', :name => 'smethod',
       :pattern => "  def self.smethod(*args)",
       :class => 'A::B'


### PR DESCRIPTION
Right now, the output from ripper-tags' Vim formatter looks like this:

```
CliTest	./test/test_cli.rb	/^class CliTest < Test::Unit::TestCase$/;"	c	inherits:Test.Unit.TestCase
DataReader	./lib/ripper-tags/data_reader.rb	/^  class DataReader$/;"	c	class:RipperTags
DataReaderTest	./test/test_data_reader.rb	/^class DataReaderTest < Test::Unit::TestCase$/;"	c	inherits:Test.Unit.TestCase
DefaultFormatter	./lib/ripper-tags/default_formatter.rb	/^  class DefaultFormatter$/;"	c	class:RipperTags
```

The leading `./` is not there in the ctags output. This simple change makes it compatible. Adding `--tag-relative` still does the trick if you output the tag file somewhere in a nested directory. The tests are passing, except one, `test_extract_associations_with_class_name`, which seems to be failing on master anyway.

A slight improvement to code clarity might be to do something like this instead:

``` ruby
def relative_path(tag)
  path = Pathname.new(tag.fetch(:path))
  if options.tag_relative && !stdout? && !path.absolute?
    path.relative_path_from(tag_file_dir).to_s
  else
    path.cleanpath.to_s
  end
end
```

The `path.absolute?` is a bit more readable than `path.index('/') != 0`, and I think it does the same thing. Let me know if you'd like me to do this instead.