### PR TITLE
Correctly handle relative path arguments

### DIFF
--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -23,13 +23,13 @@ module RipperTags
     end
 
     def tag_file_dir
-      @tag_file_dir ||= Pathname.new(options.tag_file_name).dirname
+      @tag_file_dir ||= Pathname.new(options.tag_file_name).realdirpath.dirname
     end
 
     def relative_path(tag)
       path = tag.fetch(:path)
       if options.tag_relative && !stdout? && path.index('/') != 0
-        Pathname.new(path).relative_path_from(tag_file_dir).to_s
+        Pathname.new(path).realpath.relative_path_from(tag_file_dir).to_s
       else
         path
       end


### PR DESCRIPTION
Passing a tags file with a different prefix than other path arguments results in this error:

```
lib/ruby/2.2.0/pathname.rb:508:in `relative_path_from':
different prefix: "" and "/home/mak/.rbenv/gems/2.2.0/gems/awesome_print-1.6.1" (ArgumentError)
```

This fixes that by calling `realpath` on the paths, and `realdirpath` on the tags file (because it might not exist yet).