### PR TITLE
Allow an optional `--tag--relative=yes` value for the flag

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -36,8 +36,8 @@ module RipperTags
              '"-" outputs to standard output') do |fname|
         options.tag_file_name = fname
       end
-      opts.on("--tag-relative", "Make file paths relative to the directory of the tag file") do
-        options.tag_relative = true
+      opts.on("--tag-relative[=OPTIONAL]", "Make file paths relative to the directory of the tag file") do |value|
+        options.tag_relative = value != "no"
       end
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do
         options.recursive = true

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -53,8 +53,19 @@ class CliTest < Test::Unit::TestCase
   end
 
   def test_tag_relative_on
-    options = process_args(%w[ -R --tag-relative ])
+    options = process_args(%w[--tag-relative hello.rb])
     assert_equal true, options.tag_relative
+    assert_equal %w[hello.rb], options.files
+  end
+
+  def test_tag_relative_explicit_yes
+    options = process_args(%w[-R --tag-relative=yes])
+    assert_equal true, options.tag_relative
+  end
+
+  def test_tag_relative_explicit_no
+    options = process_args(%w[-R --tag-relative=no])
+    assert_equal false, options.tag_relative
   end
 
   def test_tag_relative_on_for_emacs


### PR DESCRIPTION
This is for compatibility with `ctags` CLI.

Fixes #35

/cc @toupeira