### PR TITLE
Fix extracting name of namespaced constant

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -306,10 +306,17 @@ end
         return on_module_or_class(kind, [name, line], superclass, rhs[4])
       end
 
+      namespace = @namespace
+      if name.include?('::')
+        parts = name.split('::')
+        name = parts.pop
+        namespace = namespace + parts
+      end
+
       emit_tag :constant, line,
         :name => name,
-        :full_name => (@namespace + [name]).join('::'),
-        :class => @namespace.join('::')
+        :full_name => (namespace + [name]).join('::'),
+        :class => namespace.join('::')
     end
 
     def on_alias(name, other, line)

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -76,6 +76,25 @@ class TagRipperTest < Test::Unit::TestCase
     ], tags.map{ |t| t[:full_name] }
   end
 
+  def test_extract_namespaced_constant
+    tags = extract(<<-EOC)
+      A::B::C = 1
+      module A::B
+        D::E = 2
+      end
+    EOC
+
+    assert_equal 3, tags.size
+
+    assert_equal 'C', tags[0][:name]
+    assert_equal 'A::B::C', tags[0][:full_name]
+    assert_equal 'A::B', tags[0][:class]
+
+    assert_equal 'E', tags[2][:name]
+    assert_equal 'A::B::D::E', tags[2][:full_name]
+    assert_equal 'A::B::D', tags[2][:class]
+  end
+
   def test_extract_access
     tags = extract(<<-EOC)
       class Test


### PR DESCRIPTION
Ensures that the tag's `name` property doesn't include the namespace.

Fixes #32