### PR TITLE
Improve gemspec and add dev scripts

### DIFF
--- a/ripper-tags.gemspec
+++ b/ripper-tags.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.files = `git ls-files`.split("\n")
+  s.files = `git ls-files -z -- README* LICENSE* bin lib`.split("\0")
 end

--- a/ripper-tags.gemspec
+++ b/ripper-tags.gemspec
@@ -1,6 +1,12 @@
+version_from_source = -> (file) do
+  File.open(File.expand_path("../#{file}", __FILE__)) do |source|
+    source.each { |line| return $1 if line =~ /\bversion\b.+"(.+?)"/i }
+  end
+end
+
 Gem::Specification.new do |s|
   s.name = 'ripper-tags'
-  s.version = '0.1.3'
+  s.version = version_from_source.('lib/ripper-tags.rb')
 
   s.summary = 'ctags generator for ruby code'
   s.description = 'fast, accurate ctags generator for ruby source code using Ripper'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+
+bundle install

--- a/script/release
+++ b/script/release
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -eu
+
+fields=( $(gem build *.gemspec | grep '\(Version\|File\):' | awk '{print $2}') )
+version="${fields[0]}"
+gem="${fields[1]}"
+[ -n "$version" ] || exit 1
+trap "rm -f '$gem'" EXIT
+
+git commit --allow-empty -a -m "ripper-tags $version"
+git tag "v${version}"
+git push origin HEAD "v${version}"
+gem push "$gem"

--- a/script/test
+++ b/script/test
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+export RUBYOPT="$RUBYOPT -w"
+
+if [ "$#" -gt 0 ]; then
+  bundle exec ruby -Ilib:test "$@"
+else
+  bundle exec rake test
+fi


### PR DESCRIPTION
* Gemspec now inherits library version from source code
* Gem now only includes runtime files
* `script/bootstrap` & `script/test`
* `script/release`