### PR TITLE
Implement `--tag-kinds` option for compatibility as ctags external parser

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -76,6 +76,22 @@ module RipperTags
       opts.on_tail("--force", "Skip files with parsing errors") do
         options.force = true
       end
+      opts.on_tail("--list-kinds=LANG", "Print tag kinds that this parser supports and exit") do |lang|
+        if lang.downcase == "ruby"
+          puts((<<-OUT).gsub(/^ +/, ''))
+            c  classes
+            f  methods
+            m  modules
+            F  singleton methods
+            C  constants
+            a  aliases
+          OUT
+          exit
+        else
+          $stderr.puts "Error: language %p is not supported" % lang
+          exit 1
+        end
+      end
       opts.on_tail("-v", "--version", "Print version information") do
         puts opts.ver
         exit


### PR DESCRIPTION
ctags implements a `--xcmd-<LANG>=COMMAND` option that can be used to specify a command as an external parser for specific language.

The external parser needs to implement `--tag-kinds` for compatibility.

https://github.com/universal-ctags/ctags/blob/master/docs/xcmd.rst

Fixes #28

/cc @UmkaDK