### PR TITLE
Support `--extra=q` option to add fully qualified constant names

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -1,5 +1,6 @@
 require 'optparse'
 require 'ostruct'
+require 'set'
 require 'ripper-tags/parser'
 require 'ripper-tags/data_reader'
 require 'ripper-tags/default_formatter'
@@ -13,6 +14,7 @@ module RipperTags
   def self.default_options
     OpenStruct.new \
       :format => nil,
+      :extra_flags => Set.new,
       :tag_file_name => "./tags",
       :tag_relative => nil,
       :debug => false,
@@ -60,6 +62,16 @@ module RipperTags
       end
       opts.on("-e", "--emacs", "Output Emacs format (default if `--tag-file' is `TAGS')") do
         options.format = "emacs"
+      end
+      opts.on("--extra=FLAGS", "Specify extra flags for the formatter") do |flags|
+        flags = flags.split("")
+        operation = :add
+        if flags[0] == "+" || flags[0] == "-"
+          operation = :delete if flags.shift == "-"
+        else
+          options.extra_flags.clear
+        end
+        flags.each { |f| options.extra_flags.send(operation, f) }
       end
 
       opts.separator ""

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -11,6 +11,8 @@ require 'ripper-tags/json_formatter'
 module RipperTags
   def self.version() "0.1.3" end
 
+  FatalError = Class.new(RuntimeError)
+
   def self.default_options
     OpenStruct.new \
       :format => nil,
@@ -132,7 +134,7 @@ module RipperTags
     when "emacs"  then RipperTags::EmacsFormatter
     when "json"   then RipperTags::JSONFormatter
     when "custom" then RipperTags::DefaultFormatter
-    else raise ArgumentError, "unknown format: #{options.format.inspect}"
+    else raise FatalError, "unknown format: #{options.format.inspect}"
     end.new(options)
   end
 
@@ -144,5 +146,11 @@ module RipperTags
         formatter.write(tag, out)
       end
     end
+  rescue FatalError => err
+    $stderr.puts "%s: %s" % [
+      File.basename($0),
+      err.message
+    ]
+    exit 1
   end
 end

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -49,6 +49,10 @@ module RipperTags
       end
     end
 
+    def constant?(tag)
+      tag[:kind] == 'class' || tag[:kind] == 'module' || tag[:kind] == 'constant'
+    end
+
     def display_kind(tag)
       case tag.fetch(:kind)
       when /method$/ then 'def'

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -11,7 +11,10 @@ module RipperTags
       if @options.extra_flags
         unsupported = @options.extra_flags - supported_flags.to_set
         if unsupported.any?
-          raise ArgumentError, "these flags are not supported: %s" % unsupported.to_a.join(", ")
+          raise FatalError, "these flags are not supported in the '%s' format: %s" % [
+            options.format,
+            unsupported.to_a.join(", ")
+          ]
         end
       end
     end

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'set'
 
 module RipperTags
   class DefaultFormatter
@@ -6,6 +7,19 @@ module RipperTags
 
     def initialize(options)
       @options = options
+
+      if @options.extra_flags
+        unsupported = @options.extra_flags - supported_flags.to_set
+        if unsupported.any?
+          raise ArgumentError, "these flags are not supported: %s" % unsupported.to_a.join(", ")
+        end
+      end
+    end
+
+    def supported_flags() [] end
+
+    def extra_flag?(flag)
+      options.extra_flags && options.extra_flags.include?(flag)
     end
 
     def stdout?

--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -2,6 +2,13 @@ require 'ripper-tags/default_formatter'
 
 module RipperTags
   class VimFormatter < DefaultFormatter
+    def supported_flags() ['q'] end
+
+    def include_qualified_names?
+      return @include_qualified_names if defined? @include_qualified_names
+      @include_qualified_names = extra_flag?('q')
+    end
+
     def header
       <<-EOC
 !_TAG_FILE_FORMAT\t2\t/extended format; --format=1 will not append ;" to lines/
@@ -23,6 +30,9 @@ module RipperTags
 
     def write(tag, out)
       @queued_write << format(tag)
+      if include_qualified_names? && tag[:full_name] != tag[:name] && constant?(tag)
+        @queued_write << format(tag, :full_name)
+      end
     end
 
     def display_constant(const)
@@ -49,6 +59,10 @@ module RipperTags
       end
     end
 
+    def constant?(tag)
+      tag[:kind] == "class" || tag[:kind] == "module" || tag[:kind] == "constant"
+    end
+
     def display_kind(tag)
       case tag.fetch(:kind)
       when 'method' then 'f'
@@ -60,13 +74,13 @@ module RipperTags
       end
     end
 
-    def format(tag)
+    def format(tag, name_field = :name)
       "%s\t%s\t/^%s$/;\"\t%s%s%s" % [
-        tag.fetch(:name),
+        tag.fetch(name_field),
         relative_path(tag),
         display_pattern(tag),
         display_kind(tag),
-        display_class(tag),
+        name_field == :full_name ? nil : display_class(tag),
         display_inheritance(tag),
       ]
     end

--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -59,10 +59,6 @@ module RipperTags
       end
     end
 
-    def constant?(tag)
-      tag[:kind] == "class" || tag[:kind] == "module" || tag[:kind] == "constant"
-    end
-
     def display_kind(tag)
       case tag.fetch(:kind)
       when 'method' then 'f'

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,5 +1,6 @@
 require 'test/unit'
 require 'stringio'
+require 'set'
 require 'ripper-tags'
 
 class CliTest < Test::Unit::TestCase
@@ -71,6 +72,21 @@ class CliTest < Test::Unit::TestCase
   def test_tag_relative_on_for_emacs
     options = process_args(%w[ -R -e ])
     assert_equal true, options.tag_relative
+  end
+
+  def test_no_extra_flags_by_default
+    options = process_args(%w[ -R ])
+    assert options.extra_flags.empty?
+  end
+
+  def test_extra_flags
+    options = process_args(%w[ -R --extra=ab ])
+    assert_equal %w[a b].to_set, options.extra_flags
+  end
+
+  def test_extra_flag_modifiers
+    options = process_args(%w[ -R --extra=xy --extra=abc --extra=-ac --extra=+de ])
+    assert_equal %w[b d e].to_set, options.extra_flags
   end
 
   def with_program_name(name)

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -93,6 +93,27 @@ TAGS
     ))
   end
 
+  def test_emacs_with_fully_qualified
+    emacs = formatter_for(:format => 'emacs', :extra_flags => %w[q].to_set, :tag_file_name => '-')
+
+    output = capture_stdout do
+      emacs.with_output do |out|
+        emacs.write build_tag(
+          :kind => 'class', :name => 'C', :full_name => 'A::B::C',
+          :pattern => "class C < D",
+          :class => 'A::B', :inherits => 'D'
+        ), out
+      end
+    end
+
+    assert_equal <<-TAGS, output
+\x0C
+./script.rb,42
+class C < D\x7FC\x011,0
+class C < D\x7FA::B::C\x011,0
+TAGS
+  end
+
   def test_emacs_file_section_headers
     emacs = formatter_for(:format => 'emacs', :tag_file_name => '-')
 


### PR DESCRIPTION
For each namespaced class, module, or constant, this adds another entry to the output with the constant name expanded to be fully qualified.

Fixes #27

/cc @mweaverh