### PR TITLE
Improve JSON formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec
 
 gem 'rake'
 gem 'ripper', :platforms => :mri_18
+gem 'yajl-ruby', :platforms => :mri_18

--- a/lib/ripper-tags/json_formatter.rb
+++ b/lib/ripper-tags/json_formatter.rb
@@ -7,11 +7,23 @@ require 'ripper-tags/default_formatter'
 
 module RipperTags
   class JSONFormatter < DefaultFormatter
+    def supported_flags() ['s'] end
+
+    def stream_format?
+      return @stream_format if defined? @stream_format
+      @stream_format = extra_flag?('s')
+    end
+
     def with_output
       super do |true_out|
         buffer = []
         yield buffer
-        true_out << ::JSON.dump(buffer)
+
+        if stream_format?
+          buffer.each { |tag| true_out.puts ::JSON.dump(tag) }
+        else
+          true_out.write ::JSON.dump(buffer)
+        end
       end
     end
 

--- a/lib/ripper-tags/json_formatter.rb
+++ b/lib/ripper-tags/json_formatter.rb
@@ -1,5 +1,5 @@
 begin
-  require 'yajl'
+  require 'yajl/json_gem' unless defined?(::JSON)
 rescue LoadError
   require 'json'
 end
@@ -7,14 +7,16 @@ require 'ripper-tags/default_formatter'
 
 module RipperTags
   class JSONFormatter < DefaultFormatter
-    if defined?(::Yajl)
-      def format(tag)
-        Yajl.dump(tag)
+    def with_output
+      super do |true_out|
+        buffer = []
+        yield buffer
+        true_out << ::JSON.dump(buffer)
       end
-    else
-      def format(tag)
-        JSON.dump(tag)
-      end
+    end
+
+    def write(tag, buffer)
+      buffer << tag
     end
   end
 end

--- a/lib/ripper-tags/json_formatter.rb
+++ b/lib/ripper-tags/json_formatter.rb
@@ -1,10 +1,20 @@
-require 'yajl'
+begin
+  require 'yajl'
+rescue LoadError
+  require 'json'
+end
 require 'ripper-tags/default_formatter'
 
 module RipperTags
   class JSONFormatter < DefaultFormatter
-    def format(tag)
-      Yajl.dump(tag)
+    if defined?(::Yajl)
+      def format(tag)
+        Yajl.dump(tag)
+      end
+    else
+      def format(tag)
+        JSON.dump(tag)
+      end
     end
   end
 end

--- a/ripper-tags.gemspec
+++ b/ripper-tags.gemspec
@@ -17,8 +17,6 @@ Gem::Specification.new do |s|
   s.authors = ['Aman Gupta']
   s.email = ['aman@tmm1.net']
 
-  s.add_dependency 'yajl-ruby'
-
   s.require_paths = ['lib']
   s.bindir = 'bin'
   s.executables << 'ripper-tags'

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -171,6 +171,29 @@ def imethod\x7Fimethod\x013,0
     assert_equal expected, JSON.load(output)
   end
 
+  def test_json_stream_format
+    json = formatter_for(:format => 'json', :extra_flags => %w[s].to_set, :tag_file_name => '-')
+    tags = []
+    tags << build_tag(:name => 'A')
+    tags << build_tag(:name => 'B')
+
+    expected = [
+      {"kind"=>"class", "line"=>1, "path"=>"./script.rb", "access"=>"public", "name"=>"A"},
+      {"kind"=>"class", "line"=>1, "path"=>"./script.rb", "access"=>"public", "name"=>"B"}
+    ]
+
+    output = capture_stdout do
+      json.with_output do |out|
+        tags.each { |tag| json.write(tag, out) }
+      end
+    end
+
+    lines = output.split("\n")
+    assert_equal 2, lines.length
+    assert_equal expected[0], JSON.load(lines[0])
+    assert_equal expected[1], JSON.load(lines[1])
+  end
+
   def capture_stdout
     old_stdout, $stdout = $stdout, StringIO.new
     begin

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -151,6 +151,26 @@ def imethod\x7Fimethod\x013,0
     assert_equal 'path/to/script.rb', formatter.relative_path(tag)
   end
 
+  def test_json_format
+    json = formatter_for(:format => 'json', :tag_file_name => '-')
+    tags = []
+    tags << build_tag(:name => 'A')
+    tags << build_tag(:name => 'B')
+
+    expected = [
+      {"kind"=>"class", "line"=>1, "path"=>"./script.rb", "access"=>"public", "name"=>"A"},
+      {"kind"=>"class", "line"=>1, "path"=>"./script.rb", "access"=>"public", "name"=>"B"}
+    ]
+
+    output = capture_stdout do
+      json.with_output do |out|
+        tags.each { |tag| json.write(tag, out) }
+      end
+    end
+
+    assert_equal expected, JSON.load(output)
+  end
+
   def capture_stdout
     old_stdout, $stdout = $stdout, StringIO.new
     begin


### PR DESCRIPTION
* Output one big JSON array instead of one JSON hash per each line of output. This can simplify parsing for the consumer. **Backwards incompatible.**
* Drops strict yajl-ruby dependecy. Now tries to load "yajl" and falls back to "json".

/cc @tmm1