### PR TITLE
Handle relative path option when path to tags file is absolute

### DIFF
--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -40,13 +40,13 @@ module RipperTags
     end
 
     def tag_file_dir
-      @tag_file_dir ||= Pathname.new(options.tag_file_name).dirname
+      @tag_file_dir ||= Pathname.new(options.tag_file_name).dirname.expand_path
     end
 
     def relative_path(tag)
       path = tag.fetch(:path)
       if options.tag_relative && !stdout? && path.index('/') != 0
-        Pathname.new(path).relative_path_from(tag_file_dir).to_s
+        Pathname.new(path).expand_path.relative_path_from(tag_file_dir).to_s
       else
         path
       end

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -145,6 +145,20 @@ def imethod\x7Fimethod\x013,0
     assert_equal '../path/to/script.rb', formatter.relative_path(tag)
   end
 
+  def test_relative_with_absolute_tags_file_path
+    tag_file_name = File.join(Dir.pwd,'.git/tags')
+    formatter = formatter_for(:format => 'custom', :tag_file_name => tag_file_name, :tag_relative => true)
+    tag = build_tag(:path => 'path/to/script.rb')
+    assert_equal '../path/to/script.rb', formatter.relative_path(tag)
+  end
+
+  def test_relative_with_common_prefix
+    tag_file_name = File.join(Dir.pwd,'path/tags')
+    formatter = formatter_for(:format => 'custom', :tag_file_name => tag_file_name, :tag_relative => true)
+    tag = build_tag(:path => 'path/to/script.rb')
+    assert_equal 'to/script.rb', formatter.relative_path(tag)
+  end
+
   def test_no_relative
     formatter = formatter_for(:format => 'custom', :tag_file_name => '.git/tags')
     tag = build_tag(:path => 'path/to/script.rb')


### PR DESCRIPTION
This is to finish what was started in https://github.com/tmm1/ripper-tags/pull/36 . It makes `--tag-relative` option work when the path to tags file is absolute.