### PR TITLE
Fix "undefined method" exception for private/protected/public clauses

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -108,7 +108,7 @@ class Parser < Ripper
   end
 
   def on_vcall(name)
-    [name[0].to_sym] if name[0].to_s =~ /private|protected|public$/
+    [name[0].to_sym] if name[0].to_s =~ /^(private|protected|public)$/
   end
 
   def on_call(lhs, op, rhs)

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -423,4 +423,15 @@ class TagRipperTest < Test::Unit::TestCase
       assert_equal 'foo', tags[1][:name]
     end
   end
+
+  def test_attr_protected
+    tags = extract(<<-EOC)
+      class A
+        attr_protected
+      end
+    EOC
+
+    assert_equal 1, tags.size
+    assert_equal 'A', tags[0][:name]
+  end
 end


### PR DESCRIPTION
Fixed exception: "NoMethodError: undefined method `on_attr_protected' for
<RipperTags::Visitor:0x000000022f56c8>`"