### PR TITLE
Fix crash when parsing a `!condition`

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -388,5 +388,6 @@ end
     alias on_field on_call
     alias on_fcall on_call
     alias on_args on_call
+    alias on_! on_call
   end
 end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -450,4 +450,17 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 'foo', tags[0][:name]
     assert_equal 'bar', tags[1][:name]
   end
+
+  def test_bare_bang
+    tags = extract(<<-EOC)
+      if condition
+      elsif !other
+        # `!other` triggered crash in `elsif` clause
+      end
+      # also triggered when bare:
+      !condition
+    EOC
+
+    assert_equal 0, tags.size
+  end
 end


### PR DESCRIPTION
A bare `!condition` works when inside a method definition, or when part of an `if` clause, but when `!condition` was used either at the top-level or in an `elsif` clause, the missing `on_!` callback caused a crash.

```
$ cat bang.rb
!true
$ ripper-tags bang.rb
/Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/parser.rb:257:in `process': undefined method `on_!' for #<RipperTags::Visitor:0x007fceea8bf2c0> (NoMethodError)
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/parser.rb:234:in `initialize'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:152:in `new'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:152:in `tag_extractor'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:123:in `block in each_tag'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:69:in `resolve_file'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:85:in `block in each_file'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:84:in `each'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:84:in `each_file'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/data_reader.rb:120:in `each_tag'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:148:in `block in run'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/vim_formatter.rb:24:in `block in with_output'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/default_formatter.rb:43:in `block in with_output'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/default_formatter.rb:42:in `open'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/default_formatter.rb:42:in `with_output'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags/vim_formatter.rb:21:in `with_output'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:147:in `run'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:129:in `call'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:129:in `block in process_args'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:114:in `block in option_parser'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/2.3.0/optparse.rb:1061:in `initialize'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:33:in `new'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:33:in `option_parser'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/lib/ripper-tags.rb:119:in `process_args'
	from /Users/nathan/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/ripper-tags-0.3.4/bin/ripper-tags:15:in `<top (required)>'
	from /Users/nathan/.rbenv/versions/2.3.1/bin/ripper-tags:23:in `load'
	from /Users/nathan/.rbenv/versions/2.3.1/bin/ripper-tags:23:in `<main>'
```