### PR TITLE
Support constants defined within arrays or hashes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 gemspec
 
-gem 'pry'
 gem 'rake', '~> 10.5'
 gem 'test-unit', '~> 3.0.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 gemspec
 
+gem 'pry'
 gem 'rake', '~> 10.5'
 gem 'test-unit', '~> 3.0.8'
 gem 'ripper', :platforms => :mri_18

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -1,4 +1,5 @@
 require 'ripper'
+require 'pp'
 
 module RipperTags
 
@@ -231,10 +232,15 @@ class Parser < Ripper
   end
 end
 
-puts "Parser instance methods:"
-puts Parser.instance_methods.sort
-puts "\n\nSCANNER_EVENTS:"
-puts Ripper::SCANNER_EVENTS.sort
+puts "sexp: "
+code = <<~CODE
+  DISPLAY_MAPPING = {
+    CANCELLED = 'cancelled' => 'Cancelled by user',
+  }
+CODE
+
+pp Parser.sexp(code)
+pp Parser.new(code, 'input').parse
 
   class Visitor
     attr_reader :tags

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -104,8 +104,8 @@ class Parser < Ripper
     end
   end
 
-  def on_assoc_new(*args)
-    args.compact
+  def on_hash(args)
+    args
   end
 
   undef on_tstring_content

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -407,9 +407,5 @@ puts Ripper::SCANNER_EVENTS.sort
     alias on_fcall on_call
     alias on_args on_call
     alias on_! on_call
-
-    def on_assoc(*args)
-      puts "on_assoc called with #{args.inspect} from #{caller.join("\n")}"
-    end
   end
 end

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -95,6 +95,12 @@ class Parser < Ripper
     end
   end
 
+  def on_array(args)
+    if args && args[0] == :args
+      args[1..-1]
+    end
+  end
+
   def on_assoc_new(*args)
     args
   end
@@ -389,7 +395,6 @@ end
     end
 
     def on_args(*args)
-      process(args)
     end
 
     def on_call(*args)

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -5,6 +5,7 @@ module RipperTags
 class Parser < Ripper
   def self.extract(data, file='(eval)')
     sexp = new(data, file).parse
+    puts "parsed sexp: #{sexp.inspect}"
     Visitor.new(sexp, file, data).tags
   end
 

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -233,7 +233,7 @@ class Parser < Ripper
 end
 
 puts "sexp: "
-code = <<~CODE
+code = <<-CODE
   DISPLAY_MAPPING = {
     CANCELLED = 'cancelled' => 'Cancelled by user',
   }

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -65,9 +65,6 @@ class Parser < Ripper
   def on_binary(*args)
   end
 
-  def on_unary(*args)
-  end
-
   def on_command(name, *args)
     case name[0]
     when "define_method", "alias_method",

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -65,6 +65,9 @@ class Parser < Ripper
   def on_binary(*args)
   end
 
+  def on_unary(*args)
+  end
+
   def on_command(name, *args)
     case name[0]
     when "define_method", "alias_method",

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -401,5 +401,9 @@ end
     alias on_fcall on_call
     alias on_args on_call
     alias on_! on_call
+
+    def on_assoc(*args)
+      puts "on_assoc called with #{args.inspect} from #{caller.join("\n")}"
+    end
   end
 end

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -397,14 +397,12 @@ end
       @namespace.pop
     end
 
-    def on_args(*args)
-    end
-
     def on_call(*args)
     end
     alias on_aref_field on_call
     alias on_field on_call
     alias on_fcall on_call
+    alias on_args on_call
     alias on_! on_call
   end
 end

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -231,6 +231,11 @@ class Parser < Ripper
   end
 end
 
+puts "Parser instance methods:"
+puts Parser.instance_methods.sort
+puts "\n\nSCANNER_EVENTS:"
+puts Ripper::SCANNER_EVENTS.sort
+
   class Visitor
     attr_reader :tags
 

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -105,7 +105,7 @@ class Parser < Ripper
   end
 
   def on_assoc_new(*args)
-    args
+    args.compact
   end
 
   undef on_tstring_content

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -95,6 +95,10 @@ class Parser < Ripper
     end
   end
 
+  def on_assoc_new(*args)
+    args
+  end
+
   undef on_tstring_content
   def on_tstring_content(str)
     str
@@ -320,6 +324,8 @@ end
         namespace = namespace + parts
       end
 
+      process(rhs)
+
       emit_tag :constant, line,
         :name => name,
         :full_name => (namespace + [name]).join('::'),
@@ -382,12 +388,15 @@ end
       @namespace.pop
     end
 
+    def on_args(*args)
+      process(args)
+    end
+
     def on_call(*args)
     end
     alias on_aref_field on_call
     alias on_field on_call
     alias on_fcall on_call
-    alias on_args on_call
     alias on_! on_call
   end
 end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -78,32 +78,22 @@ class TagRipperTest < Test::Unit::TestCase
 
   def test_nested_constant_definitions
     tags = extract(<<-EOC)
-      A = [
-        B = 1,
-        C = 2
+      STATUSES = [
+        OPEN = 'open',
       ]
 
-      D = {
-        E = 3 => F = 4,
-        x: G = 5
-      }
-
-      H = []
-
-      I = [
-        J = [
-          K = 1
-        ]
-      ]
-
-      L = {
-        'some key' => {
-          M = 2 => 3
-        }
+      DISPLAY_MAPPING = {
+        CANCELLED = 'cancelled' => 'Cancelled by user',
       }
     EOC
 
-    assert_equal ('A'..'M').to_a, tags.map { |t| t[:name] }.sort
+    assert_equal %w[
+      OPEN
+      STATUSES
+      CANCELLED
+      DISPLAY_MAPPING
+    ], tags.map { |t| t[:name] }
+
     tags.each do |t|
       assert_equal t[:name], t[:full_name]
     end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -84,6 +84,7 @@ class TagRipperTest < Test::Unit::TestCase
 
       DISPLAY_MAPPING = {
         CANCELLED = 'cancelled' => 'Cancelled by user',
+        STARTED = 'started' => 'Started by user',
       }
     EOC
 
@@ -91,6 +92,7 @@ class TagRipperTest < Test::Unit::TestCase
       OPEN
       STATUSES
       CANCELLED
+      STARTED
       DISPLAY_MAPPING
     ], tags.map { |t| t[:name] }
 

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -87,9 +87,23 @@ class TagRipperTest < Test::Unit::TestCase
         E = 3 => F = 4,
         x: G = 5
       }
+
+      H = []
+
+      I = [
+        J = [
+          K = 1
+        ]
+      ]
+
+      L = {
+        'some key' => {
+          M = 2 => 3
+        }
+      }
     EOC
 
-    assert_equal ('A'..'G').to_a, tags.map { |t| t[:name] }.sort
+    assert_equal ('A'..'M').to_a, tags.map { |t| t[:name] }.sort
     tags.each do |t|
       assert_equal t[:name], t[:full_name]
     end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -76,6 +76,25 @@ class TagRipperTest < Test::Unit::TestCase
     ], tags.map{ |t| t[:full_name] }
   end
 
+  def test_nested_constant_definitions
+    tags = extract(<<-EOC)
+      A = [
+        B = 1,
+        C = 2
+      ]
+
+      D = {
+        E = 3 => F = 4,
+        x: G = 5
+      }
+    EOC
+
+    assert_equal ('A'..'G').to_a, tags.map { |t| t[:name] }.sort
+    tags.each do |t|
+      assert_equal t[:name], t[:full_name]
+    end
+  end
+
   def test_extract_namespaced_constant
     tags = extract(<<-EOC)
       A::B::C = 1


### PR DESCRIPTION
Our code base includes examples such as:
```
STATUSES = [
  OPEN = 'open',
  ...
]

DISPLAY_MAPPING = {
  CANCELLED = 'cancelled' => 'Cancelled by user',
  ...
}
```
currently, `OPEN` and `CANCELLED` are not picked up by ripper-tags. 

This PR aims to support such nested definitions.

~I'm not 100% certain of the implications of making `on_args` now process its args when it was ignoring them before, but none of the existing tests fail.~ Please let me know what you think!