### PR TITLE
Add support for `delegate`, `def_delegator` and `def_delegators`

### DIFF
--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -316,6 +316,55 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal '3: scope C.red',  inspect(tags[2])
   end
 
+  def test_extract_delegate
+    tags = extract(<<-EOC)
+      class C
+        delegate :foo,
+                 :bar, to: :thingy
+        delegate :x, to: :thingy, prefix: true
+        delegate :y, to: :thingy, prefix: :pos
+
+        delegate :z, :to => :thingy, :prefix => true
+        delegate :gamma, :to => :thingy, :prefix => :radiation
+
+        def thingy
+          Object.new
+        end
+      end
+    EOC
+
+    assert_equal 8, tags.count
+    assert_equal '2: method C#foo', inspect(tags[1])
+    assert_equal '3: method C#bar', inspect(tags[2])
+    assert_equal '4: method C#thingy_x', inspect(tags[3])
+    assert_equal '5: method C#pos_y', inspect(tags[4])
+    assert_equal '7: method C#thingy_z', inspect(tags[5])
+    assert_equal '8: method C#radiation_gamma', inspect(tags[6])
+  end
+
+  def test_def_delegator
+    tags = extract(<<-EOC)
+      class F
+        def_delegator :@things, :size, :count
+      end
+    EOC
+
+    assert_equal 2, tags.count
+    assert_equal '2: method F#count', inspect(tags[1])
+  end
+
+  def test_def_delegators
+    tags = extract(<<-EOC)
+      class F
+        def_delegators :@things, :foo, :bar
+      end
+    EOC
+
+    assert_equal 3, tags.count
+    assert_equal '2: method F#foo', inspect(tags[1])
+    assert_equal '2: method F#bar', inspect(tags[2])
+  end
+
   def test_extract_from_erb
     tags = extract(<<-EOC)
       class NavigationTest < ActionDispatch::IntegrationTest

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -327,22 +327,27 @@ class TagRipperTest < Test::Unit::TestCase
         delegate :z, :to => :thingy, :prefix => true
         delegate :gamma, :to => :thingy, :prefix => :radiation
 
+        delegate :exist?, to: :@model
+        delegate :count, to: :@items, prefix: :itm
+
         def thingy
           Object.new
         end
       end
     EOC
 
-    assert_equal 8, tags.count
+    assert_equal 10, tags.count
     assert_equal '2: method C#foo', inspect(tags[1])
     assert_equal '3: method C#bar', inspect(tags[2])
     assert_equal '4: method C#thingy_x', inspect(tags[3])
     assert_equal '5: method C#pos_y', inspect(tags[4])
     assert_equal '7: method C#thingy_z', inspect(tags[5])
     assert_equal '8: method C#radiation_gamma', inspect(tags[6])
+    assert_equal '10: method C#exist?', inspect(tags[7])
+    assert_equal '11: method C#itm_count', inspect(tags[8])
   end
 
-  def test_def_delegator
+  def test_extract_def_delegator
     tags = extract(<<-EOC)
       class F
         def_delegator :@things, :size, :count
@@ -353,7 +358,7 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal '2: method F#count', inspect(tags[1])
   end
 
-  def test_def_delegators
+  def test_extract_def_delegators
     tags = extract(<<-EOC)
       class F
         def_delegators :@things, :foo, :bar

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -350,12 +350,14 @@ class TagRipperTest < Test::Unit::TestCase
   def test_extract_def_delegator
     tags = extract(<<-EOC)
       class F
+        def_delegator :@things, :[]
         def_delegator :@things, :size, :count
       end
     EOC
 
-    assert_equal 2, tags.count
-    assert_equal '2: method F#count', inspect(tags[1])
+    assert_equal 3, tags.count
+    assert_equal '2: method F#[]', inspect(tags[1])
+    assert_equal '3: method F#count', inspect(tags[2])
   end
 
   def test_extract_def_delegators


### PR DESCRIPTION
This adds support for methods declared with either of

| style | example |
| - | - |
| [Module.delegate](http://www.rubydoc.info/gems/activesupport/Module%3Adelegate) |  `delegate :this, to: :that` |
| [Forwardable.def_delegator](http://ruby-doc.org/stdlib-2.0.0/libdoc/forwardable/rdoc/Forwardable.html#method-i-def_instance_delegator) | `def_delegator :target, :old_name, :new_name` |
| [Forwardable.def_delegators](http://ruby-doc.org/stdlib-2.0.0/libdoc/forwardable/rdoc/Forwardable.html#method-i-def_instance_delegators) | `def_delegators :target, :one, :two, :three` |

All of these will show up as regular methods, declared at the line where their identifier was listed. For `def_delegator`, the actual method name added is its last argument (using original name if alias not provided), while for `delegate` both prefixed and unprefixed forms are supported (with either `prefix: :explicit` or `prefix: true` to use target's name).