### PR TITLE
Add option to include line number for vim formatter

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -32,6 +32,17 @@ module RipperTags
   end
 
   def self.option_parser(options)
+    flags_string_to_set = lambda do |string, set|
+      flags = string.split("")
+      operation = :add
+      if flags[0] == "+" || flags[0] == "-"
+        operation = :delete if flags.shift == "-"
+      else
+        set.clear
+      end
+      flags.each { |f| set.send(operation, f) }
+    end
+
     OptionParser.new do |opts|
       opts.banner = "Usage: #{opts.program_name} [options] FILES..."
       opts.version = version
@@ -61,15 +72,8 @@ module RipperTags
       opts.on("-n", "Equivalent to --excmd=number.") do
         options.excmd = "number"
       end
-      opts.on("--fields=+n", "Include line number information in the tag") do |fields|
-        fields = fields.split("")
-        operation = :add
-        if fields[0] == "+" || fields[0] == "-"
-          operation = :delete if fields.shift == "-"
-        else
-          options.fields.clear
-        end
-        fields.each { |f| options.fields.send(operation, f) }
+      opts.on("--fields=+n", "Include line number information in the tag") do |flags|
+        flags_string_to_set.call(flags, options.fields)
       end
       opts.on("--all-files", "Parse all files as ruby files, not just `*.rb' ones") do
         options.all_files = true
@@ -84,14 +88,7 @@ module RipperTags
         options.format = "emacs"
       end
       opts.on("--extra=FLAGS", "Specify extra flags for the formatter") do |flags|
-        flags = flags.split("")
-        operation = :add
-        if flags[0] == "+" || flags[0] == "-"
-          operation = :delete if flags.shift == "-"
-        else
-          options.extra_flags.clear
-        end
-        flags.each { |f| options.extra_flags.send(operation, f) }
+        flags_string_to_set.call(flags, options.extra_flags)
       end
 
       opts.separator ""

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -26,7 +26,8 @@ module RipperTags
       :files => %w[.],
       :recursive => false,
       :exclude => %w[.git],
-      :all_files => false
+      :all_files => false,
+      :fields => Set.new
   end
 
   def self.option_parser(options)
@@ -52,6 +53,16 @@ module RipperTags
         else
           options.exclude << pattern
         end
+      end
+      opts.on("--fields=+n", "Include line number information in the tag") do |fields|
+        fields = fields.split("")
+        operation = :add
+        if fields[0] == "+" || fields[0] == "-"
+          operation = :delete if fields.shift == "-"
+        else
+          options.fields.clear
+        end
+        fields.each { |f| options.fields.send(operation, f) }
       end
       opts.on("--all-files", "Parse all files as ruby files, not just `*.rb' ones") do
         options.all_files = true

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -27,7 +27,8 @@ module RipperTags
       :recursive => false,
       :exclude => %w[.git],
       :all_files => false,
-      :fields => Set.new
+      :fields => Set.new,
+      :excmd => nil
   end
 
   def self.option_parser(options)
@@ -53,6 +54,12 @@ module RipperTags
         else
           options.exclude << pattern
         end
+      end
+      opts.on("--excmd=number", "Use EX number command to locate tags.") do |excmd|
+        options.excmd = excmd
+      end
+      opts.on("-n", "Equivalent to --excmd=number.") do
+        options.excmd = "number"
       end
       opts.on("--fields=+n", "Include line number information in the tag") do |fields|
         fields = fields.split("")

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -9,19 +9,13 @@ module RipperTags
 
     def initialize(options)
       @options = options
+      check_supported_flags(@options.extra_flags, supported_flags)
+      check_supported_flags(@options.fields, supported_fields)
+    end
 
-      if @options.extra_flags
-        unsupported = @options.extra_flags - supported_flags.to_set
-        if unsupported.any?
-          raise FatalError, "these flags are not supported in the '%s' format: %s" % [
-            options.format,
-            unsupported.to_a.join(", ")
-          ]
-        end
-      end
-
-      if @options.fields
-        unsupported = @options.fields - supported_fields.to_set
+    def check_supported_flags(set, supported)
+      if set
+        unsupported = set - supported.to_set
         if unsupported.any?
           raise FatalError, "these fields are not supported in the '%s' format: %s" % [
             options.format,

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -19,12 +19,28 @@ module RipperTags
           ]
         end
       end
+
+      if @options.fields
+        unsupported = @options.fields - supported_fields.to_set
+        if unsupported.any?
+          raise FatalError, "these fields are not supported in the '%s' format: %s" % [
+            options.format,
+            unsupported.to_a.join(", ")
+          ]
+        end
+      end
     end
 
     def supported_flags() [] end
 
     def extra_flag?(flag)
       options.extra_flags && options.extra_flags.include?(flag)
+    end
+
+    def supported_fields() [] end
+
+    def field?(field)
+      options.fields && options.fields.include?(field)
     end
 
     def stdout?

--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -40,8 +40,12 @@ module RipperTags
       const.to_s.gsub('::', '.')
     end
 
-    def display_pattern(tag)
-      tag.fetch(:pattern).to_s.gsub('\\','\\\\\\\\').gsub('/','\\/')
+    def display_excmd_info(tag)
+      if options.excmd == "number"
+        "%s;\"" % tag.fetch(:line).to_s
+      else
+        "/^%s$/;\"" % tag.fetch(:pattern).to_s.gsub('\\','\\\\\\\\').gsub('/','\\/')
+      end
     end
 
     def display_class(tag)
@@ -80,10 +84,10 @@ module RipperTags
     end
 
     def format(tag, name_field = :name)
-      "%s\t%s\t/^%s$/;\"\t%s%s%s%s" % [
+      "%s\t%s\t%s\t%s%s%s%s" % [
         tag.fetch(name_field),
         relative_path(tag),
-        display_pattern(tag),
+        display_excmd_info(tag),
         display_kind(tag),
         display_line_number(tag),
         name_field == :full_name ? nil : display_class(tag),

--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -42,7 +42,7 @@ module RipperTags
 
     def display_excmd_info(tag)
       if options.excmd == "number"
-        "%s;\"" % tag.fetch(:line).to_s
+        "%d;\"" % tag.fetch(:line)
       else
         "/^%s$/;\"" % tag.fetch(:pattern).to_s.gsub('\\','\\\\\\\\').gsub('/','\\/')
       end

--- a/lib/ripper-tags/vim_formatter.rb
+++ b/lib/ripper-tags/vim_formatter.rb
@@ -3,6 +3,7 @@ require 'ripper-tags/default_formatter'
 module RipperTags
   class VimFormatter < DefaultFormatter
     def supported_flags() ['q'] end
+    def supported_fields() ['n'] end
 
     def include_qualified_names?
       return @include_qualified_names if defined? @include_qualified_names
@@ -59,6 +60,14 @@ module RipperTags
       end
     end
 
+    def display_line_number(tag)
+      if field?('n') && tag[:line]
+        "\tline:%s" % tag[:line]
+      else
+        ""
+      end
+    end
+
     def display_kind(tag)
       case tag.fetch(:kind)
       when 'method' then 'f'
@@ -71,11 +80,12 @@ module RipperTags
     end
 
     def format(tag, name_field = :name)
-      "%s\t%s\t/^%s$/;\"\t%s%s%s" % [
+      "%s\t%s\t/^%s$/;\"\t%s%s%s%s" % [
         tag.fetch(name_field),
         relative_path(tag),
         display_pattern(tag),
         display_kind(tag),
+        display_line_number(tag),
         name_field == :full_name ? nil : display_class(tag),
         display_inheritance(tag),
       ]

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -81,6 +81,24 @@ class FormattersTest < Test::Unit::TestCase
     ))
   end
 
+  def test_vim_with_excmd_number
+    vim = formatter_for(:format => 'vim', :excmd => "number")
+    assert_equal %{C\t./script.rb\t1;"\tc}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D"
+    ))
+    assert_equal %{C\t./script.rb\t42;"\tc}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D",
+      :line => 42
+    ))
+    assert_equal %{C\t./script.rb\t105499;"\tc}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D",
+      :line => 105499
+    ))
+  end
+
   def test_vim_with_fully_qualified
     vim = formatter_for(:format => 'vim', :extra_flags => %w[q].to_set, :tag_file_name => '-')
 

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -63,6 +63,24 @@ class FormattersTest < Test::Unit::TestCase
     ))
   end
 
+  def test_vim_with_line_numbers
+    vim = formatter_for(:format => 'vim', :fields => %w(n).to_set)
+    assert_equal %{C\t./script.rb\t/^class C < D$/;"\tc\tline:1}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D"
+    ))
+    assert_equal %{C\t./script.rb\t/^class C < D$/;"\tc\tline:42}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D",
+      :line => 42
+    ))
+    assert_equal %{C\t./script.rb\t/^class C < D$/;"\tc\tline:105499}, vim.format(build_tag(
+      :kind => 'class', :name => 'C',
+      :pattern => "class C < D",
+      :line => 105499
+    ))
+  end
+
   def test_vim_with_fully_qualified
     vim = formatter_for(:format => 'vim', :extra_flags => %w[q].to_set, :tag_file_name => '-')
 


### PR DESCRIPTION
I was using tagbar with ripper-tags, but I couldn't jump to the tag definition because ripper-tags output doesn't have the line number information.

Not sure if this is just my need, `ripper-tags` might consider adding an option to support line number information. If you think this is a good feature, I could open another PR to add the `-l` option.

Thanks.