### PR TITLE
Support one-line method declaration with access

### DIFF
--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -95,7 +95,7 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 'A::B::D', tags[2][:class]
   end
 
-  def test_extract_access
+  def test_extract_access_and_kind
     tags = extract(<<-EOC)
       class Test
         def abc() end
@@ -105,13 +105,33 @@ class TagRipperTest < Test::Unit::TestCase
         def ghi() end
       public
         def jkl() end
+      private def mno() end
+      protected def pqr() end
+      public def stu() end
+      public_class_method def self.abcd() end
+      private_class_method def self.efgh() end
+      public_class_method
+        def self.ijkl() end
+      private_class_method
+        def self.mnop() end
       end
     EOC
 
-    assert_equal nil,         tags.find{ |t| t[:name] == 'abc' }[:access]
-    assert_equal 'private',   tags.find{ |t| t[:name] == 'def' }[:access]
-    assert_equal 'protected', tags.find{ |t| t[:name] == 'ghi' }[:access]
-    assert_equal 'public',    tags.find{ |t| t[:name] == 'jkl' }[:access]
+    assert_equal nil,                tags.find{ |t| t[:name] == 'abc' }[:access]
+    assert_equal 'private',          tags.find{ |t| t[:name] == 'def' }[:access]
+    assert_equal 'protected',        tags.find{ |t| t[:name] == 'ghi' }[:access]
+    assert_equal 'public',           tags.find{ |t| t[:name] == 'jkl' }[:access]
+    assert_equal 'private',          tags.find{ |t| t[:name] == 'mno' }[:access]
+    assert_equal 'protected',        tags.find{ |t| t[:name] == 'pqr' }[:access]
+    assert_equal 'public',           tags.find{ |t| t[:name] == 'stu' }[:access]
+    assert_equal 'public',           tags.find{ |t| t[:name] == 'abcd' }[:access]
+    assert_equal 'singleton method', tags.find{ |t| t[:name] == 'abcd' }[:kind]
+    assert_equal 'private',          tags.find{ |t| t[:name] == 'efgh' }[:access]
+    assert_equal 'singleton method', tags.find{ |t| t[:name] == 'efgh' }[:kind]
+    assert_equal 'public',           tags.find{ |t| t[:name] == 'ijkl' }[:access]
+    assert_equal 'singleton method', tags.find{ |t| t[:name] == 'ijkl' }[:kind]
+    assert_equal 'private',          tags.find{ |t| t[:name] == 'mnop' }[:access]
+    assert_equal 'singleton method', tags.find{ |t| t[:name] == 'mnop' }[:kind]
   end
 
   def test_extract_module_eval


### PR DESCRIPTION
We could write Ruby code like this because `def` will return the defined method itself:

``` ruby
private_class_method def self.foo
  'bar'
end
```

Previously, `ripper-tags` won't recognize them and generate the concrete tag, this PR will add the support.