### PR TITLE
Support an input file of pathnames

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -58,6 +58,7 @@ module RipperTags
         options.tag_relative = value != "no"
       end
       opts.on("-L", "--input-files=FILE", "Read paths to process from given file; use `-` for stdin") do |file|
+        options.all_files = true
         options.input_file = file
       end
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -57,7 +57,7 @@ module RipperTags
       opts.on("--tag-relative[=OPTIONAL]", "Make file paths relative to the directory of the tag file") do |value|
         options.tag_relative = value != "no"
       end
-      opts.on("-L", "--input-files=FILE", "Read paths to process from given file; use `-` for stdin") do |file|
+      opts.on("-L", "--input-file=FILE", "File to read paths to process trom (use `-` for stdin)") do |file|
         options.input_file = file
       end
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -28,7 +28,8 @@ module RipperTags
       :exclude => %w[.git],
       :all_files => false,
       :fields => Set.new,
-      :excmd => nil
+      :excmd => nil,
+      :input_file => nil
   end
 
   def self.option_parser(options)
@@ -55,6 +56,9 @@ module RipperTags
       end
       opts.on("--tag-relative[=OPTIONAL]", "Make file paths relative to the directory of the tag file") do |value|
         options.tag_relative = value != "no"
+      end
+      opts.on("-L", "--input-files=FILE", "Read paths to process from given file; use `-` for stdin") do |file|
+        options.input_file = file
       end
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do
         options.recursive = true
@@ -135,8 +139,8 @@ module RipperTags
       file_list = optparse.parse(argv)
       if !file_list.empty?
         options.files = file_list
-      elsif !options.recursive
-        raise OptionParser::InvalidOption, "needs either a list of files or `-R' flag"
+      elsif !(options.recursive || options.input_file)
+        raise OptionParser::InvalidOption, "needs either a list of files, `-L`, or `-R' flag"
       end
       options.tag_file_name ||= options.format == 'emacs' ? './TAGS' : './tags'
       options.format ||= File.basename(options.tag_file_name) == 'TAGS' ? 'emacs' : 'vim'

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -58,7 +58,6 @@ module RipperTags
         options.tag_relative = value != "no"
       end
       opts.on("-L", "--input-files=FILE", "Read paths to process from given file; use `-` for stdin") do |file|
-        options.all_files = true
         options.input_file = file
       end
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do
@@ -80,7 +79,7 @@ module RipperTags
       opts.on("--fields=+n", "Include line number information in the tag") do |flags|
         flags_string_to_set.call(flags, options.fields)
       end
-      opts.on("--all-files", "Parse all files as ruby files, not just `*.rb' ones") do
+      opts.on("--all-files", "Parse all files in recursive mode (default: parse `*.rb' files)") do
         options.all_files = true
       end
 

--- a/lib/ripper-tags/data_reader.rb
+++ b/lib/ripper-tags/data_reader.rb
@@ -49,8 +49,8 @@ module RipperTags
       file.end_with?(RUBY_EXT)
     end
 
-    def include_file?(file)
-      (options.all_files || ruby_file?(file)) && !exclude_file?(file)
+    def include_file?(file, depth)
+      (depth == 0 || options.all_files || ruby_file?(file)) && !exclude_file?(file)
     end
 
     def resolve_file(file, depth = 0, &block)
@@ -66,7 +66,7 @@ module RipperTags
         end
       elsif depth > 0 || File.exist?(file)
         file = clean_path(file) if depth == 0
-        yield file if include_file?(file)
+        yield file if include_file?(file, depth)
       else
         $stderr.puts "%s: %p: no such file or directory" % [
           File.basename($0),

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,6 +1,7 @@
 require 'test/unit'
 require 'stringio'
 require 'set'
+require 'tempfile'
 require 'ripper-tags'
 
 class CliTest < Test::Unit::TestCase
@@ -12,7 +13,7 @@ class CliTest < Test::Unit::TestCase
     err = assert_raise(OptionParser::InvalidOption) do
       RipperTags.process_args([])
     end
-    assert_equal "invalid option: needs either a list of files or `-R' flag", err.message
+    assert_equal "invalid option: needs either a list of files, `-L`, or `-R' flag", err.message
   end
 
   def test_invalid_option
@@ -107,6 +108,12 @@ class CliTest < Test::Unit::TestCase
   def test_extra_flag_modifiers
     options = process_args(%w[ -R --extra=xy --extra=abc --extra=-ac --extra=+de ])
     assert_equal %w[b d e].to_set, options.extra_flags
+  end
+
+  def test_input_file
+    test_input_path = "/ripper-tags/is/awesome"
+    options = process_args(['-L', test_input_path])
+    assert_equal test_input_path, options.input_file
   end
 
   def capture_stderr

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -1,7 +1,6 @@
 require 'test/unit'
 require 'stringio'
 require 'set'
-require 'tempfile'
 require 'ripper-tags'
 
 class CliTest < Test::Unit::TestCase

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -91,6 +91,46 @@ class DataReaderTest < Test::Unit::TestCase
     end
   end
 
+  def test_input_file
+    test_inputs = %w[encoding.rb very/inter.rb]
+    with_tempfile(test_inputs) do |test_input_io|
+      test_input_io.close
+      options = OpenStruct.new(:input_file => test_input_io.path)
+      finder = RipperTags::FileFinder.new(options)
+      assert_equal test_inputs, finder.each_file.to_a
+    end
+  end
+
+  def test_input_file_as_stdin
+    test_inputs = %w[encoding.rb very/inter.rb]
+    with_tempfile(test_inputs, :stringio => true) do |test_input_io|
+      test_input_io.rewind
+      orig_stdin, $stdin = $stdin, test_input_io
+      begin
+        options = OpenStruct.new(:input_file => "-")
+        finder = RipperTags::FileFinder.new(options)
+        assert_equal test_inputs, finder.each_file.to_a
+      ensure
+        $stdin = orig_stdin
+      end
+    end
+  end
+
+  def with_tempfile(lines, options={}, &block)
+    stringio = options[:stringio]
+    in_fixtures do
+      test_input_io = stringio ? StringIO.new : Tempfile.new("test-ripper-tags")
+      lines.each { |line| test_input_io.puts(line) }
+
+      begin
+        block.call(test_input_io)
+      ensure
+        test_input_io.close if ! test_input_io.closed?
+        File.delete(test_input_io.path) if ! stringio
+      end
+    end
+  end
+
   def ignore_warnings
     old_verbose = $-w
     $-w = false

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -47,7 +47,7 @@ class DataReaderTest < Test::Unit::TestCase
 
   def test_file_finder_no_exclude
     files = in_fixtures { find_files('.', :exclude => []) }
-    assert files.include?('_git/hooks/hook.rb'), files.inspect
+    assert_include files, '_git/hooks/hook.rb'
   end
 
   def test_file_finder_exclude
@@ -72,6 +72,27 @@ class DataReaderTest < Test::Unit::TestCase
       very/inter.rb
     ]
     assert_equal expected, files.sort
+  end
+
+  def test_file_finder_all
+    files = in_fixtures { find_files('.', :all_files => true) }
+    assert_include files, 'non-script.txt'
+    assert_include files, 'very/deep/non-ruby.py'
+  end
+
+  def test_file_finder_always_include_exact_match
+    files = in_fixtures { find_files('non-script.txt', 'very', :all_files => false) }
+    expected = %w[
+      non-script.txt
+      very/deep/script.rb
+      very/inter.rb
+    ]
+    assert_equal expected, files.sort
+  end
+
+  def test_file_finder_exact_match_respects_exclude
+    files = in_fixtures { find_files('encoding.rb', :exclude => ['encoding']) }
+    assert_equal [], files
   end
 
   def in_fixtures

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -1,3 +1,4 @@
+require 'tempfile'
 require 'test/unit'
 require 'ostruct'
 require 'ripper-tags/data_reader'
@@ -93,41 +94,35 @@ class DataReaderTest < Test::Unit::TestCase
 
   def test_input_file
     test_inputs = %w[encoding.rb very/inter.rb]
-    with_tempfile(test_inputs) do |test_input_io|
-      test_input_io.close
-      options = OpenStruct.new(:input_file => test_input_io.path)
-      finder = RipperTags::FileFinder.new(options)
-      assert_equal test_inputs, finder.each_file.to_a
+    with_tempfile do |tempfile|
+      test_inputs.each { |line| tempfile.puts(line) }
+      tempfile.close
+      in_fixtures do
+        assert_equal test_inputs, find_files(:input_file => tempfile.path)
+      end
     end
   end
 
   def test_input_file_as_stdin
     test_inputs = %w[encoding.rb very/inter.rb]
-    with_tempfile(test_inputs, :stringio => true) do |test_input_io|
-      test_input_io.rewind
-      orig_stdin, $stdin = $stdin, test_input_io
-      begin
-        options = OpenStruct.new(:input_file => "-")
-        finder = RipperTags::FileFinder.new(options)
-        assert_equal test_inputs, finder.each_file.to_a
-      ensure
-        $stdin = orig_stdin
+    fake_stdin = StringIO.new(test_inputs.join("\n"))
+    orig_stdin, $stdin = $stdin, fake_stdin
+    begin
+      in_fixtures do
+        assert_equal test_inputs, find_files(:input_file => "-")
       end
+    ensure
+      $stdin = orig_stdin
     end
   end
 
-  def with_tempfile(lines, options={}, &block)
-    stringio = options[:stringio]
-    in_fixtures do
-      test_input_io = stringio ? StringIO.new : Tempfile.new("test-ripper-tags")
-      lines.each { |line| test_input_io.puts(line) }
-
-      begin
-        block.call(test_input_io)
-      ensure
-        test_input_io.close if ! test_input_io.closed?
-        File.delete(test_input_io.path) if ! stringio
-      end
+  def with_tempfile
+    file = Tempfile.new("test-ripper-tags")
+    begin
+      yield file
+    ensure
+      file.close unless file.closed?
+      File.delete(file.path)
     end
   end
 


### PR DESCRIPTION
Thanks for this great project! I made this change because I have large project trees with mixed Ruby and non-Ruby files, and some of the Ruby files do not end in `.rb`.

I have a script that figures out all the Ruby files. There may be thousands of files to process, with long relative pathnames, so they simply won't fit on the command line. And even with `xargs` multiple passes would be required.

With this new option I can put all the pathnames into a file and process them all in 1 pass. It uses the short-form `-L` to coincide with the `ctags` tool.

I hope you find it useful.