### PR TITLE
Support `--ignore unsupported-options`

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -152,7 +152,6 @@ module RipperTags
             argv.delete(bad_option)
             invalid_options << bad_option
           end
-          retry
         end
       end
       

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -146,14 +146,13 @@ module RipperTags
       while argv.size > 0
         begin
           file_list = optparse.parse(argv)
+          break
         rescue OptionParser::InvalidOption => err
           err.args.each do |bad_option|
             argv.delete(bad_option)
             invalid_options << bad_option
           end
           retry
-        else
-          break
         end
       end
       

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -17,9 +17,16 @@ class CliTest < Test::Unit::TestCase
 
   def test_invalid_option
     err = assert_raise(OptionParser::InvalidOption) do
-      RipperTags.process_args(%[--moo])
+      RipperTags.process_args(%w[--moo])
     end
     assert_equal "invalid option: --moo", err.message
+  end
+
+  def test_invalid_option_with_ignored
+    err = assert_raise(OptionParser::InvalidOption) do
+      RipperTags.process_args(%w[--moo --ignore-unsupported-options])
+    end
+    assert_equal "invalid option: needs either a list of files, `-L`, or `-R' flag", err.message
   end
 
   def test_recurse_defaults_to_current_dir

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -29,6 +29,17 @@ class CliTest < Test::Unit::TestCase
     assert_equal "invalid option: needs either a list of files, `-L`, or `-R' flag", err.message
   end
 
+  def test_invalid_options_ignored_plus_files
+    options = process_args(%w[--moo lib --ignore-unsupported-options --language=perl src])
+    assert_equal %w[lib src], options.files
+  end
+
+  def test_invalid_options_ignored_recursive_current_dir
+    options = process_args(%w[--moo --ignore-unsupported-options -O2 -R])
+    assert_equal true, options.recursive
+    assert_equal %w[.], options.files
+  end
+
   def test_recurse_defaults_to_current_dir
     options = process_args(%w[-R])
     assert_equal true, options.recursive


### PR DESCRIPTION
This addresses an issue raised in #54: to have an option that turns on tolerant mode, ignoring any unknown commandline options.