### PR TITLE
fixes an issue when `delegate *options` was used

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -78,7 +78,7 @@ class Parser < Ripper
     when "delegate"
       arg = *args[0]
       if !arg.empty?
-        on_delegate(arg[1..-1])
+        on_delegate(*args[0][1..-1])
       end
     when "def_delegator", "def_instance_delegator"
       on_def_delegator(*args[0][1..-1])

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -76,7 +76,10 @@ class Parser < Ripper
          /^attr_(accessor|reader|writer)$/
       on_method_add_arg([:fcall, name], args[0])
     when "delegate"
-      on_delegate(*args[0][1..-1])
+      arg = *args[0]
+      if !arg.empty?
+        on_delegate(*args[0][1..-1])
+      end
     when "def_delegator", "def_instance_delegator"
       on_def_delegator(*args[0][1..-1])
     when "def_delegators", "def_instance_delegators"

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -78,7 +78,7 @@ class Parser < Ripper
     when "delegate"
       arg = *args[0]
       if !arg.empty?
-        on_delegate(*args[0][1..-1])
+        on_delegate(arg[1..-1])
       end
     when "def_delegator", "def_instance_delegator"
       on_def_delegator(*args[0][1..-1])

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -421,6 +421,10 @@ class TagRipperTest < Test::Unit::TestCase
         delegate :count, to: :@items, prefix: :itm
         delegate :headers, to: "@_response"
 
+        options = [:one, :two]
+        options << { to: :thingy }
+        delegate *options
+
         def thingy
           Object.new
         end


### PR DESCRIPTION
this was exposed when trying to parse https://github.com/flyerhzm/bullet/blob/master/lib/bullet.rb#L36-L38
```ruby
  available_notifiers = UniformNotifier::AVAILABLE_NOTIFIERS.map { |notifier| "#{notifier}=" }
  available_notifiers << { :to => UniformNotifier }
  delegate *available_notifiers
```