### PR TITLE
Parse mattr_* and cattr_* module accessors, writers and readers

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -73,7 +73,7 @@ class Parser < Ripper
          "scope", "named_scope",
          "public_class_method", "private_class_method",
          "public", "protected", "private",
-         /^attr_(accessor|reader|writer)$/
+         /^[mc]?attr_(accessor|reader|writer)$/
       on_method_add_arg([:fcall, name], args[0])
     when "delegate"
       on_delegate(*Array(args[0])[1..-1])
@@ -185,7 +185,7 @@ class Parser < Ripper
         [:def_with_access, klass, method_name, access, line]
       when "scope", "named_scope"
         [:rails_def, :scope, args[1][0], line]
-      when /^attr_(accessor|reader|writer)$/
+      when /^[mc]?attr_(accessor|reader|writer)$/
         gen_reader = $1 != 'writer'
         gen_writer = $1 != 'reader'
         args[1..-1].inject([]) do |gen, arg|

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -358,6 +358,42 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal '4: method M#b=', inspect(tags[8])
   end
 
+  def test_extract_mattr_accessor
+    tags = extract(<<-EOC)
+      module M
+        mattr_accessor :a, "b"
+        mattr_reader(:a, :b)
+        mattr_writer(:a, :b)
+      end
+    EOC
+    assert_equal '2: method M#a',  inspect(tags[1])
+    assert_equal '2: method M#a=', inspect(tags[2])
+    assert_equal '2: method M#b',  inspect(tags[3])
+    assert_equal '2: method M#b=', inspect(tags[4])
+    assert_equal '3: method M#a',  inspect(tags[5])
+    assert_equal '3: method M#b',  inspect(tags[6])
+    assert_equal '4: method M#a=', inspect(tags[7])
+    assert_equal '4: method M#b=', inspect(tags[8])
+  end
+
+  def test_extract_cattr_accessor
+    tags = extract(<<-EOC)
+      module M
+        cattr_accessor :a, "b"
+        cattr_reader(:a, :b)
+        cattr_writer(:a, :b)
+      end
+    EOC
+    assert_equal '2: method M#a',  inspect(tags[1])
+    assert_equal '2: method M#a=', inspect(tags[2])
+    assert_equal '2: method M#b',  inspect(tags[3])
+    assert_equal '2: method M#b=', inspect(tags[4])
+    assert_equal '3: method M#a',  inspect(tags[5])
+    assert_equal '3: method M#b',  inspect(tags[6])
+    assert_equal '4: method M#a=', inspect(tags[7])
+    assert_equal '4: method M#b=', inspect(tags[8])
+  end
+
   def test_extract_rails_associations
     tags = extract(<<-EOC)
       class C


### PR DESCRIPTION
Hi!

This very simple change allows the parser to emit tags not only for attr_* methods but also their module/class counterparts mattr_* and cattr_*.

Thanks for creating ripper-tags, just found it and fully replaced ctags for my ruby development in vim.

Cheers,
Frank