### PR TITLE
Process inside calls to handle frozen (nested) constants

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -498,12 +498,17 @@ end
     end
 
     def on_call(*args)
+      process args
     end
-    alias on_aref_field on_call
-    alias on_field on_call
-    alias on_fcall on_call
-    alias on_args on_call
-    alias on_assoc on_call
-    alias on_! on_call
+
+    def ignore(*args)
+    end
+
+    alias on_aref_field ignore
+    alias on_field ignore
+    alias on_fcall ignore
+    alias on_args ignore
+    alias on_assoc ignore
+    alias on_! ignore
   end
 end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -87,18 +87,26 @@ class TagRipperTest < Test::Unit::TestCase
         OPEN = 'open',
       ]
 
+      FROZEN_ARRAY = [ARRAY_ENTRY = 1].freeze
+
       DISPLAY_MAPPING = {
         CANCELLED = 'cancelled' => 'Cancelled by user',
         STARTED = 'started' => 'Started by user',
       }
+
+      FROZEN_HASH = { HASH_ENTRY = 2 => 3 }.freeze
     EOC
 
     assert_equal %w[
       OPEN
       STATUSES
+      ARRAY_ENTRY
+      FROZEN_ARRAY
       CANCELLED
       STARTED
       DISPLAY_MAPPING
+      HASH_ENTRY
+      FROZEN_HASH
     ], tags.map { |t| t[:name] }
 
     tags.each do |t|


### PR DESCRIPTION
Rubocop rightly suggests that [constants be frozen](http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/MutableConstant), unfortunately, doing so breaks the discovery of nested constants that was introduced in #63 

This PR looks "underneath" method calls, which allows frozen nested constants to be discovered. 