### PR TITLE
Handle '--append' for Vim and Emacs.

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -29,7 +29,8 @@ module RipperTags
       :all_files => false,
       :fields => Set.new,
       :excmd => nil,
-      :input_file => nil
+      :input_file => nil,
+      :append => false
   end
 
   class ForgivingOptionParser < OptionParser
@@ -86,6 +87,9 @@ module RipperTags
       opts.on("-f", "--tag-file (FILE|-)", "File to write tags to (default: `./tags')",
              '"-" outputs to standard output') do |fname|
         options.tag_file_name = fname
+      end
+      opts.on("-a", "--append[=yes|no]", "Append to existing tagfile") do |value|
+        options.append = value != "no"
       end
       opts.on("--tag-relative[=OPTIONAL]", "Make file paths relative to the directory of the tag file") do |value|
         options.tag_relative = value != "no"
@@ -186,6 +190,10 @@ module RipperTags
       options.tag_file_name ||= options.format == 'emacs' ? './TAGS' : './tags'
       options.format ||= File.basename(options.tag_file_name) == 'TAGS' ? 'emacs' : 'vim'
       options.tag_relative = options.format == "emacs" if options.tag_relative.nil?
+
+      if options.append && !(%w(emacs vim).include? options.format)
+        raise OptionParser::InvalidOption, "--append is supported only for Emacs and Vim formats"
+      end
 
       return run.call(options)
     end

--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -191,8 +191,13 @@ module RipperTags
       options.format ||= File.basename(options.tag_file_name) == 'TAGS' ? 'emacs' : 'vim'
       options.tag_relative = options.format == "emacs" if options.tag_relative.nil?
 
-      if options.append && !(%w(emacs vim).include? options.format)
-        raise OptionParser::InvalidOption, "--append is supported only for Emacs and Vim formats"
+      if options.append
+        unless %w(emacs vim).include? options.format
+          raise OptionParser::InvalidOption, "--append is supported only for Emacs and Vim formats"
+        end
+        if options.tag_file_name == "-"
+          raise OptionParser::InvalidOption, "--append is not supported with stdin/stdout"
+        end
       end
 
       return run.call(options)

--- a/lib/ripper-tags/default_formatter.rb
+++ b/lib/ripper-tags/default_formatter.rb
@@ -49,10 +49,14 @@ module RipperTags
           raise BrokenPipe
         end
       else
-        File.open(options.tag_file_name, 'w+') do |outfile|
+        prepare_output(options.tag_file_name) do |outfile|
           yield outfile
         end
       end
+    end
+
+    def prepare_output(filename, &block)
+      File.open(options.tag_file_name, 'w+', &block)
     end
 
     def tag_file_dir

--- a/lib/ripper-tags/emacs_formatter.rb
+++ b/lib/ripper-tags/emacs_formatter.rb
@@ -94,11 +94,11 @@ module RipperTags
       ]
     end
 
-    def save_rest
+    def save_rest(&block)
       @original.save_rest(&block) if @original
     end
 
-    def save_section(filename)
+    def save_section(filename, &block)
       @original.save_section(filename, &block) if @original
     end
 

--- a/lib/ripper-tags/emacs_formatter.rb
+++ b/lib/ripper-tags/emacs_formatter.rb
@@ -11,6 +11,8 @@ module RipperTags
   # new source file is encountered or when `with_output` block finishes. This
   # assumes that incoming tags are ordered by source file.
   class EmacsFormatter < DefaultFormatter
+    attr_reader :original
+
     def initialize(*)
       super
       @current_file = nil
@@ -28,24 +30,39 @@ module RipperTags
       super do |io|
         begin
           yield io
+          save_rest { |filename| start_file_section(filename, io) }
         ensure
           flush_file_section(io)
         end
       end
     end
 
+    def prepare_output(filename, &block)
+      @original = EmacsTagsProcessor.new(filename)
+      @original.read if options.append && File.readable?(filename)
+
+      super
+    end
+
     def write(tag, io)
       filename = relative_path(tag)
       section_io = start_file_section(filename, io)
-      section_io.puts format(tag)
+      # In case we have newer symbols for this file - trash old ones
+      remove_saved(tag)
+      record(section_io, tag)
+    end
+
+    def record(io, tag)
+      io.puts format(tag)
       if include_qualified_names? && tag[:full_name] != tag[:name] && constant?(tag)
-        section_io.puts format(tag, :full_name)
+        io.puts format(tag, :full_name)
       end
     end
 
     def start_file_section(filename, io)
       if filename != @current_file
         flush_file_section(io)
+
         @current_file = filename
         @section_io = StringIO.new
       else
@@ -55,6 +72,8 @@ module RipperTags
 
     def flush_file_section(out)
       if @section_io
+        save_section(@current_file) { |tag| record(@section_io, tag) }
+
         data = @section_io.string
         out.write format_section_header(@current_file, data)
         out.write data
@@ -73,6 +92,69 @@ module RipperTags
         tag.fetch(:line),
         0,
       ]
+    end
+
+    def save_rest
+      @original.save_rest(&block) if @original
+    end
+
+    def save_section(filename)
+      @original.save_section(filename, &block) if @original
+    end
+
+    def remove_saved(tag)
+      @original.remove(tag) if @original
+    end
+  end
+
+  class EmacsTagsProcessor
+    def initialize(source)
+      @source = source
+      @tags = []
+    end
+    
+    TAG_PATTERN = /^(.*)\x7F(.*)\x01(\d+),\d+/
+
+    def read
+      lines = File.readlines(@source, "\n")
+      filename = nil
+      while !lines.empty?
+        line = lines.shift
+        case line
+        when "\f\n" # Section header
+          filename, _ = lines.shift.split(",") # Filename is in next line
+        else
+          pattern, name, linenum = line.scan(TAG_PATTERN).first
+          store_tag(linenum, name, pattern, filename)
+        end
+      end
+    end
+
+    def store_tag(line, name, pattern, filename)
+      @tags.push({:line => line,
+                  :name => name,
+                  :path => filename,
+                  :pattern => pattern,
+                  :class => ""}) # Can't reconstruct class
+    end
+
+    def remove(tag)
+      @tags.reject! do |old|
+        old[:name] == tag[:name] && old[:path] == tag[:path]
+      end
+    end
+
+    def save_section(path)
+      @tags.select { |tag| tag[:path] == path }
+           .each { |tag| yield tag }
+      @tags.reject! { |tag| tag[:path] == path }
+    end
+
+    def save_rest
+      @tags.group_by { |tag| tag[:path] }
+        .each do |filename, tags|
+          yield filename unless tags.count.zero?
+        end
     end
   end
 end

--- a/test/test_append.rb
+++ b/test/test_append.rb
@@ -77,10 +77,14 @@ end
 
 module EmacsUtils
   def fixture_tags
-    [{ line: "4", name: "X", path: "x.rb", pattern: "class X", class: "" },
-     { line: "5", name: "foo", path: "x.rb", pattern: "    def foo", class: "" },
-     { line: "12", name: "SomeComponent", path: "y.js", pattern: "class SomeComponent extends React.Component {", class: "" },
-     { line: "14", name: "componentWillMount", path: "y.js", pattern: "  componentWillMount() {", class: "" }]
+    { "x.rb" => [
+      { line: "4", name: "X", path: "x.rb", pattern: "class X", class: "" },
+      { line: "5", name: "foo", path: "x.rb", pattern: "    def foo", class: "" }
+    ],
+    "y.js" => [
+      { line: "12", name: "SomeComponent", path: "y.js", pattern: "class SomeComponent extends React.Component {", class: "" },
+      { line: "14", name: "componentWillMount", path: "y.js", pattern: "  componentWillMount() {", class: "" }
+    ]}
   end
 
   def fixture_lines
@@ -177,7 +181,7 @@ class EmacsTagsProcessorTest < Test::Unit::TestCase
 
   def processor(options = {})
     ::RipperTags::EmacsTagsProcessor.new(options[:path]).tap do |obj|
-      obj.instance_variable_set :@tags, options.fetch(:tags, [])
+      obj.instance_variable_set :@tags, options.fetch(:tags, {})
     end
   end
 
@@ -219,5 +223,4 @@ class EmacsTagsProcessorTest < Test::Unit::TestCase
     subject.save_rest { |filename| out.push(filename) }
     assert_equal(%w(y.js), out)
   end
-
 end

--- a/test/test_append.rb
+++ b/test/test_append.rb
@@ -1,0 +1,223 @@
+require 'test/unit'
+require 'stringio'
+require 'ostruct'
+require 'set'
+require 'ripper-tags'
+
+class VimAppendTest < Test::Unit::TestCase
+  def test_vim_append
+    Tempfile.open("tags") do |tmp|
+      tmp.write(vim_header)
+      tmp.write(%(SomeComponent\t./src/components/some_component/index.jsx\t/^class SomeComponent extends React.Component {$/;"\tC\n))
+      tmp.write(%(X\t./xmarksthespot.rb\t/^X = 42$/;"\tC\n))
+      tmp.rewind
+
+      vim = appending_vim_formatter(tmp.path)
+      vim.with_output do |out|
+        vim.write build_tag(
+          :kind => 'class', :name => 'C', full_name: 'A::B::C',
+          :pattern => "class C < D",
+          :class => 'A::B', :inherits => 'D'), out
+      end
+      tmp.rewind
+      assert_equal <<-TAGS, tmp.read
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+A::B::C	./script.rb	/^class C < D$/;"	c	inherits:D
+C	./script.rb	/^class C < D$/;"	c	class:A.B	inherits:D
+SomeComponent	./src/components/some_component/index.jsx	/^class SomeComponent extends React.Component {$/;"	C
+X	./xmarksthespot.rb	/^X = 42$/;"	C
+TAGS
+    end
+  end
+
+  def test_vim_append_duplicates
+    Tempfile.open("tags") do |tmp|
+      tmp.write(vim_header)
+      tmp.write(%(C\t./script.rb\t/^class C < D$/;"\tc\tclass:A.B\tinherits:D\n))
+      tmp.write(%(X\t./xmarksthespot.rb\t/^X = 42$/;"\tC\n))
+      tmp.rewind
+
+      vim = appending_vim_formatter(tmp.path)
+      vim.with_output do |out|
+          vim.write build_tag(
+            :kind => 'class', :name => 'C', full_name: 'A::B::C',
+            :pattern => "class C < D",
+            :class => 'A::B', :inherits => 'D'), out
+        end
+      tmp.rewind
+      assert_equal <<-TAGS, tmp.read
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+A::B::C	./script.rb	/^class C < D$/;"	c	inherits:D
+C	./script.rb	/^class C < D$/;"	c	class:A.B	inherits:D
+X	./xmarksthespot.rb	/^X = 42$/;"	C
+TAGS
+    end
+  end
+
+  def vim_header
+    %(!_TAG_FILE_FORMAT\t2\t/extended format; --format=1 will not append ;" to lines/\n) +
+    %(!_TAG_FILE_SORTED\t1\t/0=unsorted, 1=sorted, 2=foldcase/\n)
+  end
+
+  def build_tag(attrs = {})
+    { :kind => 'class',
+      :line => 1,
+      :path => './script.rb',
+      :access => 'public',
+    }.merge(attrs)
+  end
+
+  def appending_vim_formatter(path)
+    options = OpenStruct.new(:format => 'vim', :extra_flags => %w[q].to_set, :tag_file_name => path, :append => true)
+    RipperTags.formatter_for(options)
+  end
+end
+
+module EmacsUtils
+  def fixture_tags
+    [{ line: "4", name: "X", path: "x.rb", pattern: "class X", class: "" },
+     { line: "5", name: "foo", path: "x.rb", pattern: "    def foo", class: "" },
+     { line: "12", name: "SomeComponent", path: "y.js", pattern: "class SomeComponent extends React.Component {", class: "" },
+     { line: "14", name: "componentWillMount", path: "y.js", pattern: "  componentWillMount() {", class: "" }]
+  end
+
+  def fixture_lines
+    # Nonzero byte offsets and wrong section sizes. Both are ignored/recalculated later
+    ["\f",
+     "x.rb,1234",
+     "class X\x7FX\x014,12",
+     "    def foo\x7Ffoo\x015,999",
+     "\f",
+     "y.js,9999",
+     "class SomeComponent extends React.Component {\x7FSomeComponent\x0112,133",
+     "  componentWillMount() {\x7FcomponentWillMount\x0114,19"]
+  end
+end
+
+class EmacsAppendTest < Test::Unit::TestCase
+  include EmacsUtils
+
+  def appending_emacs_formatter(path)
+    options = OpenStruct.new(:format => 'emacs', :tag_file_name => path, :append => true)
+    RipperTags.formatter_for(options)
+  end
+
+  def test_emacs_append
+    Tempfile.open("TAGS") do |tmp|
+      tmp.write(fixture_lines.join("\n"))
+      tmp.rewind
+
+      subject = appending_emacs_formatter(tmp.path)
+      subject.with_output do |out|
+        subject.write build_tag(
+          :kind => 'class', :name => 'C', full_name: 'A::B::C',
+          :pattern => "class C < D",
+          :class => 'A::B', :inherits => 'D'), out
+      end
+      tmp.rewind
+
+      # Section sizes are rewritten, and tag byte offsets are always zero
+      assert_equal([
+          "\f", "./script.rb,18",
+          "class C < D\x7FC\x011,0",
+          "\f", "x.rb,34",
+          "class X\x7FX\x014,0",
+          "    def foo\x7Ffoo\x015,0",
+          "\f", "y.js,114",
+          "class SomeComponent extends React.Component {\x7FSomeComponent\x0112,0",
+          "  componentWillMount() {\x7FcomponentWillMount\x0114,0",
+          ""
+        ].join("\n"),
+        tmp.read)
+    end
+  end
+
+  def test_emacs_append_duplicates
+    Tempfile.open("TAGS") do |tmp|
+      tmp.write(fixture_lines.join("\n"))
+      tmp.rewind
+
+      subject = appending_emacs_formatter(tmp.path)
+      subject.with_output do |out|
+        subject.write build_tag(
+          kind: 'class', name: 'X',
+          pattern: "class X", path: "x.rb", line: 3 # Different line 
+          ), out
+      end
+      tmp.rewind
+
+      # Section sizes are rewritten, and tag byte offsets are always zero
+      assert_equal([
+          "\f", "x.rb,34",
+          "class X\x7FX\x013,0",
+          "    def foo\x7Ffoo\x015,0",
+          "\f", "y.js,114",
+          "class SomeComponent extends React.Component {\x7FSomeComponent\x0112,0",
+          "  componentWillMount() {\x7FcomponentWillMount\x0114,0",
+          ""
+        ].join("\n"),
+        tmp.read)
+    end
+
+  end
+
+  def build_tag(attrs = {})
+    { :kind => 'class',
+      :line => 1,
+      :path => './script.rb',
+      :access => 'public',
+    }.merge(attrs)
+  end
+end
+
+class EmacsTagsProcessorTest < Test::Unit::TestCase
+  include EmacsUtils
+
+  def processor(options = {})
+    ::RipperTags::EmacsTagsProcessor.new(options[:path]).tap do |obj|
+      obj.instance_variable_set :@tags, options.fetch(:tags, [])
+    end
+  end
+
+  def test_read_sections
+    Tempfile.open("tags") do |tmp|
+      tmp.write(fixture_lines.join("\n"))
+      tmp.rewind
+
+      subject = processor(path: tmp.path)
+      subject.read
+
+      assert_equal(fixture_tags, subject.instance_variable_get(:@tags))
+    end
+  end
+
+  def test_save_section_emits_tags
+    out = []
+    subject = processor(tags: fixture_tags)
+
+    subject.save_section("x.rb") { |tag| out.push(tag) }
+    assert_equal(
+      [{ line: "4", name: "X", path: "x.rb", pattern: "class X", class: "" },
+       { line: "5", name: "foo", path: "x.rb", pattern: "    def foo", class: "" }],
+    out)
+  end
+
+  def test_save_rest_emits_sections
+    out = []
+    subject = processor(tags: fixture_tags)
+    subject.save_rest { |filename| out.push(filename) }
+    assert_equal(%w(x.rb y.js), out) 
+  end
+
+  def test_save_rest_omits_empty
+    out = []
+    subject = processor(tags: fixture_tags)
+    subject.remove(path: "x.rb", name: "X")
+    subject.remove(path: "x.rb", name: "foo")
+    subject.save_rest { |filename| out.push(filename) }
+    assert_equal(%w(y.js), out)
+  end
+
+end

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -157,6 +157,26 @@ class CliTest < Test::Unit::TestCase
     assert_equal test_input_path, options.input_file
   end
 
+  def test_append_flag
+    options = process_args(%w[--append --format=vim -R])
+    assert_equal true, options.append
+
+    options = process_args(%w[--append --format=emacs -R])
+    assert_equal true, options.append
+  end
+
+  def test_append_default_json_fails
+    err = assert_raise(OptionParser::InvalidOption) do 
+      RipperTags.process_args(%w[--append --format=default -R])
+    end
+    assert_equal "invalid option: --append is supported only for Emacs and Vim formats", err.message
+
+    err = assert_raise(OptionParser::InvalidOption) do 
+      RipperTags.process_args(%w[--append --format=json -R])
+    end
+    assert_equal "invalid option: --append is supported only for Emacs and Vim formats", err.message
+  end
+
   def capture_stderr
     old_stderr = $stderr
     $stderr = StringIO.new

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -177,6 +177,13 @@ class CliTest < Test::Unit::TestCase
     assert_equal "invalid option: --append is supported only for Emacs and Vim formats", err.message
   end
 
+  def test_append_stdout
+    err = assert_raise(OptionParser::InvalidOption) do
+      RipperTags.process_args(%w[-a -f - -R .])
+    end
+    assert_equal "invalid option: --append is not supported with stdin/stdout", err.message
+  end
+
   def capture_stderr
     old_stderr = $stderr
     $stderr = StringIO.new

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -129,7 +129,6 @@ C\t./script.rb\t/^class C < D$/;"\tc\tclass:A.B\tinherits:D
 TAGS
   end
 
-
   def test_emacs
     emacs = formatter_for(:format => 'emacs')
     assert_equal %{  class C < D\x7FC\x015,0}, emacs.format(build_tag(

--- a/test/test_formatters.rb
+++ b/test/test_formatters.rb
@@ -129,31 +129,6 @@ C\t./script.rb\t/^class C < D$/;"\tc\tclass:A.B\tinherits:D
 TAGS
   end
 
-  def test_vim_append
-    Tempfile.open("tags") do |tmp|
-      tmp.write(<<-TAGS)
-!_TAG_FILE_FORMAT\t2\t/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED\t1\t/0=unsorted, 1=sorted, 2=foldcase/
-X\t./xmarksthespot.rb\t/^X = 42$/;"\tC
-TAGS
-      tmp.rewind
-      vim = formatter_for(:format => 'vim', :extra_flags => %w[q].to_set, :tag_file_name => tmp.path, :append => true)
-      vim.with_output do |out|
-        vim.write build_tag(
-          :kind => 'class', :name => 'C', full_name: 'A::B::C',
-          :pattern => "class C < D",
-          :class => 'A::B', :inherits => 'D'), out
-      end
-      tmp.rewind
-      assert_equal <<-TAGS, tmp.read
-!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
-!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-A::B::C	./script.rb	/^class C < D$/;"	c	inherits:D
-C	./script.rb	/^class C < D$/;"	c	class:A.B	inherits:D
-X	./xmarksthespot.rb	/^X = 42$/;"	C
-TAGS
-    end
-  end
 
   def test_emacs
     emacs = formatter_for(:format => 'emacs')


### PR DESCRIPTION
Obviously needs more tests, but submitting a working version.

Vim and JSON formatters are simple - read existing tags, merge with new ones, output. 
For emacs, the procedure is more involved since the entries are grouped into sections per tag's file. Read the file, remove stale tags as we output new ones, and dump the rest when flushing a section. When all new tags are processed, output what remains.