### PR TITLE
Gracefully handle unreadable directories

### DIFF
--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -97,37 +97,22 @@ class DataReaderTest < Test::Unit::TestCase
     assert_equal [], files
   end
 
-  def with_unreadable_directory_and_readable_file
+  def test_unreadable_directory
     in_fixtures do
       Dir.mkdir('unreadable', 0300)
       File.write('unreadable/will_be_ignored.rb', 'def foo;end')
 
       begin
-        yield
+        files = nil
+        stderr = capture_stderr do
+          files = find_files('.', verbose: false)
+        end
+        assert_not_include files, 'unreadable/will_be_ignored.rb'
+        assert_equal stderr, "#{File.basename($0)}: skipping unreadable directory `unreadable'\n"
       ensure
         File.delete('unreadable/will_be_ignored.rb')
         Dir.rmdir('unreadable')
       end
-    end
-  end
-
-  def test_unreadable_directory
-    with_unreadable_directory_and_readable_file do
-      stderr = capture_stderr do
-        files = find_files('.', verbose: false)
-
-        assert_not_include files, 'unreadable/will_be_ignored.rb'
-      end
-
-      assert_not_include(stderr, "Ignoring unreadable directory")
-    end
-  end
-
-  def test_unreadable_directory_verbose
-    with_unreadable_directory_and_readable_file do
-      stderr = capture_stderr { find_files('.', verbose: true) }
-
-      assert_include(stderr, "Ignoring unreadable directory `unreadable'")
     end
   end
 

--- a/test/test_data_reader.rb
+++ b/test/test_data_reader.rb
@@ -97,6 +97,14 @@ class DataReaderTest < Test::Unit::TestCase
     assert_equal [], files
   end
 
+  def test_file_finder_no_recursive
+    files = in_fixtures { find_files('encoding.rb', 'very', :recursive => false) }
+    expected = %w[
+      encoding.rb
+    ]
+    assert_equal expected, files.sort
+  end
+
   def test_unreadable_directory
     in_fixtures do
       Dir.mkdir('unreadable', 0300)


### PR DESCRIPTION
If there is an unreadable directory considered by `ripper-tags`, an exception is raised:
```
.../lib/ripper-tags/data_reader.rb:59:in `open': Permission denied @ dir_initialize - foo/bar (Errno::EACCES)
	from .../lib/ripper-tags/data_reader.rb:59:in `entries'
	from .../lib/ripper-tags/data_reader.rb:59:in `resolve_file'
	from .../lib/ripper-tags/data_reader.rb:63:in `block in resolve_file'
```
(tested with 0.6.0)

This PR gracefully handles such directories, by skipping them (and logging if `--verbose` is given).

To reproduce the existing behaviour, run:
```
$ mkdir -p a/b
$ touch a/b/c.rb
$ chmod 355 a/b
$ ripper-tags --tag-file=/dev/null --recursive --verbose a # Errors
```
with this PR, we now have
```
$ bundle exec bin/ripper-tags --tag-file=/dev/null --recursive --verbose a
Ignoring unreadable directory `a/b'
```