### PR TITLE
Skip emitting tags for scopes with blank name

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -188,7 +188,8 @@ class Parser < Ripper
 
         [procedure, klass, method_name, access, line]
       when "scope", "named_scope"
-        [:rails_def, :scope, args[1][0], line]
+        scope_name = args[1][0]
+        [:rails_def, :scope, scope_name, line] if scope_name
       when /^[mc]?attr_(accessor|reader|writer)$/
         gen_reader = $1 != 'writer'
         gen_writer = $1 != 'reader'

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -474,8 +474,12 @@ class TagRipperTest < Test::Unit::TestCase
       class C
         named_scope(:red) { {:conditions=>{:color => 'red'}} }
         scope :red, where(:color => 'red')
+        scope '' do
+          get :foo
+        end
       end
     EOC
+    assert_equal 3, tags.size
     assert_equal 'Rails', tags[1][:language]
 
     assert_equal '2: scope C.red',  inspect(tags[1])


### PR DESCRIPTION
Fixes #87