### PR TITLE
Add ctags compatible --recurse alias

### DIFF
--- a/lib/ripper-tags.rb
+++ b/lib/ripper-tags.rb
@@ -103,6 +103,9 @@ module RipperTags
       opts.on("-R", "--recursive", "Descend recursively into subdirectories") do
         options.recursive = true
       end
+      opts.on("--recurse=[yes|no]", "Alias for --recursive") do |value|
+        options.recursive = value != 'no'
+      end
       opts.on("--exclude PATTERN", "Exclude a file, directory or pattern") do |pattern|
         if pattern.empty?
           options.exclude.clear

--- a/test/test_cli.rb
+++ b/test/test_cli.rb
@@ -70,6 +70,16 @@ class CliTest < Test::Unit::TestCase
     assert_equal %w[.], options.files
   end
 
+  def test_recursive_ctags_compatible_alias
+    options = process_args(%w[--recurse])
+    assert_equal true, options.recursive
+  end
+
+  def test_recursive_ctags_when_alias_when_set_to_no
+    options = process_args(%w[--recurse=no -L .])
+    assert_equal false, options.recursive
+  end
+
   def test_exclude_add_patterns
     options = process_args(%w[-R --exclude vendor --exclude=bundle/*])
     assert_equal %w[.git vendor bundle/*], options.exclude


### PR DESCRIPTION
Exhuberant Ctags has `--recurse` instead of `--recursive`, this just introduces `--recurse=[yes|no]`  to the CLI  to make the interface compatible (will avoid hacks with generic tags plugins in editors, in my case the well known https://github.com/ludovicchabant/vim-gutentags):

```
$ ctags --help | grep recur
  -R   Equivalent to --recurse.
  --recurse=[yes|no]
```

```
$ bundle exec bin/ripper-tags --help | grep recur
    -R, --recursive                  Descend recursively into subdirectories
        --recurse=[yes|no]           Alias for --recursive
        --all-files                  Parse all files in recursive mode (default: parse `*.rb' files)
```

Behaviour is the same as `--recursive`:

```
$ bundle exec bin/ripper-tags --recurse --verbose
Parsing file `test/test_ripper_tags.rb'
Parsing file `test/fixtures/_git/hooks/hook.rb'
Parsing file `test/fixtures/erb_template.rb'
...
```

Small difference is that it supports the `--recurse=yes|no` style like Ctags:

```
$ bundle exec bin/ripper-tags --recurse=no --verbose
ripper-tags: invalid option: needs either a list of files, `-L`, or `-R' flag
```
 