### PR TITLE
Handle decorators/method modifiers

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -89,10 +89,12 @@ class Parser < Ripper
     when "def_delegators", "def_instance_delegators"
       on_def_delegators(*args[0][1..-1])
     else
-      # Handle decorators: if what follows is a method def, pass it on
-      _, inner = args[0]
-      if inner[0] == :def
-        on_def inner[1..-1], nil, nil
+      if args[0].respond_to?(:[])
+        # Handle decorators: if what follows is a method def, pass it on
+        inner = args[0][1]
+        if inner.respond_to?(:[]) && inner[0] == :def
+          on_def(inner[1..-1], nil, nil)
+        end
       end
     end
   end

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -88,6 +88,12 @@ class Parser < Ripper
       on_def_delegator(*args[0][1..-1])
     when "def_delegators", "def_instance_delegators"
       on_def_delegators(*args[0][1..-1])
+    else
+      # Handle decorators: if what follows is a method def, pass it on
+      _, inner = args[0]
+      if inner[0] == :def
+        on_def inner[1..-1], nil, nil
+      end
     end
   end
   def on_bodystmt(*args)
@@ -361,6 +367,7 @@ end
     end
 
     def process(sexp)
+      puts sexp.inspect
       return unless sexp
       return if Symbol === sexp
 

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -367,7 +367,6 @@ end
     end
 
     def process(sexp)
-      puts sexp.inspect
       return unless sexp
       return if Symbol === sexp
 

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -787,6 +787,7 @@ class TagRipperTest < Test::Unit::TestCase
   def test_decorated_method
     tags = extract(<<-EOC)
       class Foo
+        puts "%d" % 1
         memoize def calculate; end
       end
     EOC

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -783,4 +783,16 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 2, tags.size
     assert_equal 'C', tags[1][:name]
   end
+
+  def test_decorated_method
+    tags = extract(<<-EOC)
+      class Foo
+        memoize def calculate; end
+      end
+    EOC
+
+    assert_equal 2, tags.size
+    assert_equal 'Foo', tags[0][:name]
+    assert_equal 'calculate', tags[1][:name]
+  end
 end


### PR DESCRIPTION
Fixes #94 
This hooks into `on_command` (which does a lot of work already) and handles any unrecognized name by checking if what follows is a method definition. And if so, passes it on to `on_def`.