### PR TITLE
Handle inner method definitions, in 4 possible styles

### DIFF
--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -848,7 +848,6 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 3, tags.size
     assert_equal '1: class A', inspect(tags[0])
     assert_equal '2: method A#outer_method', inspect(tags[1])
-    # Not entirely correct, but good enough for tagging
     assert_equal '4: singleton method A.inner_method', inspect(tags[2])
   end
 end


### PR DESCRIPTION
This addresses #92. However, having implemented it, I'm somewhat against including it, for two reasons:

1. Defining nested methods like this is usually a code smell. While ripper isn't a lint tool, leaving this unsupported makes it have an opinion on things. Rubocop [flags it](https://rubocop.readthedocs.io/en/latest/cops_lint/#lintnestedmethoddefinition) as such
2. More importantly, this requires parsing a method's body, which may have side effect I didn't consider (probably generating some useless symbols from itsinsides). A sub-parser that rejects all but method definitions inside could help. But this PR uses the naive approach.

Feel free to close it, and keep as a discussion item to point to if that reappears :)
