### PR TITLE
Generate tags for methods defined in blocks

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -293,7 +293,7 @@ class Parser < Ripper
   def on_method_add_block(method, body)
     if method.nil?
       body ? body.last : nil
-    elsif %w[class_eval module_eval].include?(method[2]) && body
+    elsif (method[2] == "class_eval" || method[2] == "module_eval") && body
       [:class_eval, [
         method[1].is_a?(Array) ? method[1][0] : method[1],
         method[3]

--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -544,12 +544,17 @@ end
     end
 
     def on_call(*args)
+      process args
     end
-    alias on_aref_field on_call
-    alias on_field on_call
-    alias on_fcall on_call
-    alias on_args on_call
-    alias on_assoc on_call
-    alias on_! on_call
+
+    def ignore(*args)
+    end
+
+    alias on_aref_field ignore
+    alias on_field ignore
+    alias on_fcall ignore
+    alias on_args ignore
+    alias on_assoc ignore
+    alias on_! ignore
   end
 end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -87,18 +87,26 @@ class TagRipperTest < Test::Unit::TestCase
         OPEN = 'open',
       ]
 
+      FROZEN_ARRAY = [ARRAY_ENTRY = 1].freeze
+
       DISPLAY_MAPPING = {
         CANCELLED = 'cancelled' => 'Cancelled by user',
         STARTED = 'started' => 'Started by user',
       }
+
+      FROZEN_HASH = { HASH_ENTRY = 2 => 3 }.freeze
     EOC
 
     assert_equal %w[
       OPEN
       STATUSES
+      ARRAY_ENTRY
+      FROZEN_ARRAY
       CANCELLED
       STARTED
       DISPLAY_MAPPING
+      HASH_ENTRY
+      FROZEN_HASH
     ], tags.map { |t| t[:name] }
 
     tags.each do |t|

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -823,4 +823,27 @@ class TagRipperTest < Test::Unit::TestCase
     assert_equal 'Foo', tags[0][:name]
     assert_equal 'calculate', tags[1][:name]
   end
+
+  def test_method_defined_in_block
+    tags = extract(<<-EOC)
+      RSpec.describe do
+        def test_method; end
+      end
+
+      module M
+        included do
+          def included_method; end
+          attr_accessor :cache
+        end
+
+        %w[sub gsub].each do |m|
+          define_method("\#{m}!") {}
+          attr_reader m
+        end
+      end
+    EOC
+
+    expected = ["Object#test_method", "M", "M#included_method", "M#cache", "M#cache="]
+    assert_equal expected, tags.map { |t| t[:full_name] }
+  end
 end


### PR DESCRIPTION
As discussed here: https://github.com/tmm1/ripper-tags/issues/94#issuecomment-551546094

Now this code will generate tags:

```ruby
some_cool_dsl_method do
  def my_method
    # ...
  end
end
```

Tested in some big projects, seems to work.

Update: also contains fix from #79 since basically it requires that change.