### PR TITLE
Fix parse error for delegate statements with dynamic arguments

### DIFF
--- a/lib/ripper-tags/parser.rb
+++ b/lib/ripper-tags/parser.rb
@@ -316,8 +316,8 @@ class Parser < Ripper
   end
 
   def on_delegate(*args)
-    method_names = args.select { |arg| arg.first.is_a? String }
-    options = args.select { |arg| arg.first.is_a?(Array) && arg.first.first == :assoc }.flatten(1)
+    method_names = args.select { |arg| arg.is_a?(Array) && arg.first.is_a?(String) }
+    options = args.select { |arg| arg.is_a?(Array) && arg.first.is_a?(Array) && arg.first.first == :assoc }.flatten(1)
     options = Hash[options.map { |_assoc, key, val| [key[0], val[0]] if key }.compact]
 
     target = options["to:"] || options["to"] # When using hashrocket syntax there is no ':'

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -846,4 +846,19 @@ class TagRipperTest < Test::Unit::TestCase
     expected = ["Object#test_method", "M", "M#included_method", "M#cache", "M#cache="]
     assert_equal expected, tags.map { |t| t[:full_name] }
   end
+
+  def test_multi_argument_delegate
+    tags = extract(<<-EOC)
+      class C
+        def object = Object.new
+        delegate :thing, :other, to: :object
+        %i(test).each do |m|
+          delegate m, :"\#{m}=", to: :object
+        end
+      end
+    EOC
+
+    expected = ["C", "C#object", "C#thing", "C#other", "C#test", "C#test="].sort
+    assert_equal expected, tags.map { |t| t[:full_name] }.sort
+  end
 end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -578,7 +578,7 @@ class TagRipperTest < Test::Unit::TestCase
       class C
         delegate
         delegate [1, 2]
-        %i(test).each do |m|
+        [:test].each do |m|
           delegate m, :"\#{m}=", :to => :object
         end
       end

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -579,7 +579,7 @@ class TagRipperTest < Test::Unit::TestCase
         delegate
         delegate [1, 2]
         %i(test).each do |m|
-          delegate m, :"\#{m}=", to: :object
+          delegate m, :"\#{m}=", :to => :object
         end
       end
     EOC

--- a/test/test_ripper_tags.rb
+++ b/test/test_ripper_tags.rb
@@ -578,6 +578,9 @@ class TagRipperTest < Test::Unit::TestCase
       class C
         delegate
         delegate [1, 2]
+        %i(test).each do |m|
+          delegate m, :"\#{m}=", to: :object
+        end
       end
     EOC
     assert_equal 1, tags.count
@@ -845,20 +848,5 @@ class TagRipperTest < Test::Unit::TestCase
 
     expected = ["Object#test_method", "M", "M#included_method", "M#cache", "M#cache="]
     assert_equal expected, tags.map { |t| t[:full_name] }
-  end
-
-  def test_multi_argument_delegate
-    tags = extract(<<-EOC)
-      class C
-        def object = Object.new
-        delegate :thing, :other, to: :object
-        %i(test).each do |m|
-          delegate m, :"\#{m}=", to: :object
-        end
-      end
-    EOC
-
-    expected = ["C", "C#object", "C#thing", "C#other", "C#test", "C#test="].sort
-    assert_equal expected, tags.map { |t| t[:full_name] }.sort
   end
 end


### PR DESCRIPTION
I updated to 1.0 today because I saw the announcement in Ruby Weekly last week. I am now getting a NoMethodError where previously there was no error when parsing (on v.0.9.1):

```
NoMethodError parsing `myfile.rb': undefined method `first' for nil:NilClass
```

To be clear, I can still use it but this particular construction seems to throw the parser.

I've made a minimal test case that recreates the behavior.

```ruby
class C
  def object = Object.new

  # these all work
  delegate :thing, to: :object
  delegate :thing=, to: :object
  %i(other).each do |k|
    delegate k, to: :object
    delegate :"#{k}", to: :object
  end

  # does not work!
  %(foo).each do |k|
    delegate k, :"#{k}=", to: :object
  end
end
```